### PR TITLE
Improvement of automatic invalidation of confiner path cache.

### DIFF
--- a/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/Runtime/Behaviours/CinemachineConfiner.cs
@@ -110,6 +110,7 @@ namespace Cinemachine
         }
 
         private List<List<Vector2>> m_pathCache;
+        private int m_pathTotalPointCount;
        
         /// <summary>Call this if the bounding shape's points change at runtime</summary>
         public void InvalidatePathCache() { m_pathCache = null; }
@@ -120,7 +121,7 @@ namespace Cinemachine
             if (colliderType == typeof(PolygonCollider2D))
             {
                 PolygonCollider2D poly = m_BoundingShape2D as PolygonCollider2D;
-                if (m_pathCache == null || m_pathCache.Count != poly.pathCount)
+                if (m_pathCache == null || m_pathCache.Count != poly.pathCount || m_pathTotalPointCount != poly.GetTotalPointCount())
                 {
                     m_pathCache = new List<List<Vector2>>();
                     for (int i = 0; i < poly.pathCount; ++i)
@@ -131,13 +132,14 @@ namespace Cinemachine
                             dst.Add(path[j]);
                         m_pathCache.Add(dst);
                     }
+                    m_pathTotalPointCount = poly.GetTotalPointCount();
                 }
                 return true;
             }
             else if (colliderType == typeof(CompositeCollider2D))
             {
                 CompositeCollider2D poly = m_BoundingShape2D as CompositeCollider2D;
-                if (m_pathCache == null || m_pathCache.Count != poly.pathCount)
+                if (m_pathCache == null || m_pathCache.Count != poly.pathCount || m_pathTotalPointCount != poly.pointCount)
                 {
                     m_pathCache = new List<List<Vector2>>();
                     Vector2[] path = new Vector2[poly.pointCount];
@@ -149,6 +151,7 @@ namespace Cinemachine
                             dst.Add(path[j]);
                         m_pathCache.Add(dst);
                     }
+                    m_pathTotalPointCount = poly.pointCount;
                 }
                 return true;
             }


### PR DESCRIPTION
This offers a small improvement in the check for the automatic invalidation of the path cache for CinemachineConfiner.  

Notably this allows a CinemachineConfiner to maintain proper functionality in all scenarios where a CompositeCollider2D has a new Collider2D added to it, without requiring the user to call InvalidatePathCache().  

Currently scenarios where an added Collider2D creates a new path are handled without the need to call InvalidatePathCache(), but scenarios where the number of paths stays the same cause improper behavior unless InvalidatePathCache() is called.  This discrepancy is what led to the creation of this pull request.  

