### PR TITLE
fix array after removing member - CinemachineTargetGroup

### DIFF
--- a/Runtime/Behaviours/CinemachineTargetGroup.cs
+++ b/Runtime/Behaviours/CinemachineTargetGroup.cs
@@ -140,8 +140,8 @@ namespace Cinemachine
                 m_Targets = new Target[m_Targets.Length - 1];
                 if (index > 0)
                     Array.Copy(oldTargets, m_Targets, index);
-                if (index < m_Targets.Length - 1)
-                    Array.Copy(oldTargets, index + 1, m_Targets, index, m_Targets.Length - index - 1);
+                if (index < m_Targets.Length)
+                    Array.Copy(oldTargets, index + 1, m_Targets, index, m_Targets.Length - index);
             }
         }
 


### PR DESCRIPTION
**Before:**
Try to remove 2 from array [0][1][2][3]

oldTargets: [0][1][2][3]
`Array.Copy(oldTargets, m_Targets, 2);`
m_Targets: [0][1][null]
`if (index < m_Targets.Length - 1)` is false because 2 < 3 - 1 => 2 < 2 => false

m_Targets should be replaced by oldTargets or "-1" isn't necessary