### PR TITLE
Fixed incorrect references in the documentation

### DIFF
--- a/Documentation~/Cinemachine2D.md
+++ b/Documentation~/Cinemachine2D.md
@@ -1,6 +1,6 @@
 # 2D graphics
 
-Cinemachine supports orthographic cameras. When you set the Unity camera's projection to Orthographic, Cinemachine adjusts to accommodate it.  In Virtual Camera properties for __Lens__, __FOV__ is replaced by __Orthographic Size__.  Note that settings related to FOV and certain FOV-oriented behaviors such as [Follow Zoom](CinemachineFollowZoom.html) have no effect if the camera is orthographic.
+Cinemachine supports orthographic cameras. When you set the Unity camera's projection to Orthographic, Cinemachine adjusts to accommodate it.  In Virtual Camera properties for __Lens__, __FOV__ is replaced by __Orthographic Size__.  Note that settings related to FOV and certain FOV-oriented behaviors such as [Follow Zoom](CinemachineFollowZoom.md) have no effect if the camera is orthographic.
 
-In orthographic environments, it doesn’t usually make sense to rotate the camera.  Accordingly, Cinemachine offers the [Framing Transposer](CinemachineBodyFramingTransposer.html) to handle framing and composition without rotating the camera.
+In orthographic environments, it doesn’t usually make sense to rotate the camera.  Accordingly, Cinemachine offers the [Framing Transposer](CinemachineBodyFramingTransposer.md) to handle framing and composition without rotating the camera.
 

--- a/Documentation~/CinemachineAimGroupComposer.md
+++ b/Documentation~/CinemachineAimGroupComposer.md
@@ -1,4 +1,4 @@
 # Group Composer
 
-This Virtual Camera __Aim__ algorithm aims the camera at multiple GameObjects. Otherwise, it behaves identically to the Composer and has the same settings. If the Look At target is a [Cinemachine Target Group](CinemachineTargetGroup.html), the algorithm adjusts the FOV and the camera distance to ensure that the group of targets is framed properly.
+This Virtual Camera __Aim__ algorithm aims the camera at multiple GameObjects. Otherwise, it behaves identically to the Composer and has the same settings. If the Look At target is a [Cinemachine Target Group](CinemachineTargetGroup.md), the algorithm adjusts the FOV and the camera distance to ensure that the group of targets is framed properly.
 

--- a/Documentation~/CinemachineBlendListCamera.md
+++ b/Documentation~/CinemachineBlendListCamera.md
@@ -4,7 +4,7 @@ The __Cinemachine Blend List Camera__ component executes a sequence of blends or
 
 When the Blend List camera is activated, it executes its list of instructions, activating the first child Virtual Camera in the list, holding for a designated time, then cutting or blending to the next child, and so on. The Blend List camera holds the last Virtual Camera until Cinemachine Brain or Timeline deactivates the Blend List camera.
 
-**Tip**: Use a Blend List Camera instead of  [Timeline](CinemachineTimeline.html) for simpler, automatic sequences.
+**Tip**: Use a Blend List Camera instead of  [Timeline](CinemachineTimeline.md) for simpler, automatic sequences.
 
 ## Properties:
 
@@ -12,7 +12,7 @@ When the Blend List camera is activated, it executes its list of instructions, a
 |:---|:---|
 | __Solo__ | Toggles whether or not the Blend List camera is temporarily live. Use this property to get immediate visual feedback in the [Game view](https://docs.unity3d.com/Manual/GameView.html) to adjust the Virtual Camera. |
 | __Game Window Guides__ | Toggles the visibility of compositional guides in the Game view. This property applies to all Virtual Cameras. |
-| __Save During Play__ | Check to [apply the changes while in Play mode](CinemachineSavingDuringPlay.html).  Use this feature to fine-tune a Virtual Camera without having to remember which properties to copy and paste. This property applies to all Virtual Cameras. |
+| __Save During Play__ | Check to [apply the changes while in Play mode](CinemachineSavingDuringPlay.md).  Use this feature to fine-tune a Virtual Camera without having to remember which properties to copy and paste. This property applies to all Virtual Cameras. |
 | __Priority__ | The importance of this Blend List camera for choosing the next shot. A higher value indicates a higher priority. Cinemachine Brain chooses the next live Virtual Camera from all Virtual Cameras that are activated and have the same or higher priority as the current live Virtual Camera. This property has no effect when using a Virtual Camera with Timeline. |
 | __Look At__ | The default target GameObject that the children Virtual Camera move with. The Blend List camera uses this target when the child does not specify this target. May be empty if all of the children define targets of their own. |
 | __Follow__ | The default target GameObject to aim the Unity camera at. The Blend List camera uses this target when the child does not specify this target. May be empty if all of the children define targets of their own. |

--- a/Documentation~/CinemachineBodyFramingTransposer.md
+++ b/Documentation~/CinemachineBodyFramingTransposer.md
@@ -8,7 +8,7 @@ This algorithm first moves the camera along the camera Z axis until the __Follow
 
 **Note**: To use __Framing Transposer__, the __Look At__ property must be empty.
 
-If the __Follow__ target is a [Target Group](CinemachineTargetGroup.html), then additional properties are available to frame the entire group.
+If the __Follow__ target is a [Target Group](CinemachineTargetGroup.md), then additional properties are available to frame the entire group.
 
 ## Properties
 
@@ -31,7 +31,7 @@ If the __Follow__ target is a [Target Group](CinemachineTargetGroup.html), then 
 | __Soft Zone Height__ || When the target is in this range, move the camera vertically to frame the target in the dead zone. The Damping properties affect the rate of the camera movement.  |
 | __Bias X__ || Moves the target position horizontally away from the center of the soft zone. |
 | __Bias Y__ || Moves the target position vertically away from the center of the soft zone. |
-| __Group Framing Mode__ || Available when Follow specifies a [Target Group](CinemachineTargetGroup.html). Specifies the screen dimensions to consider when framing.  |
+| __Group Framing Mode__ || Available when Follow specifies a [Target Group](CinemachineTargetGroup.md). Specifies the screen dimensions to consider when framing.  |
 | | _Horizontal_ | Consider only the horizontal dimension. Ignore vertical framing. |
 | | _Vertical_ | Consider only the vertical dimension. Ignore horizontal framing. |
 | | _Horizontal And Vertical_ | Use the larger of the horizontal and vertical dimensions to get the best fit. |

--- a/Documentation~/CinemachineBodyTrackedDolly.md
+++ b/Documentation~/CinemachineBodyTrackedDolly.md
@@ -1,6 +1,6 @@
 # Tracked Dolly
 
-This Virtual Camera __Body__ algorithm restricts the Virtual Camera to move along a predefined [path](CinemachineDolly.html). Use the __Path Position__ property to specify where to put the Virtual Camera on the path.
+This Virtual Camera __Body__ algorithm restricts the Virtual Camera to move along a predefined [path](CinemachineDolly.md). Use the __Path Position__ property to specify where to put the Virtual Camera on the path.
 
 Use __Auto-Dolly__ mode to move the Virtual Camera to a position on the path that is closest to the __Follow__ target. When enabled, __Auto-Dolly__ automatically animates the position of the Virtual Camera to the position on the path that’s closest to the target.
 
@@ -10,7 +10,7 @@ Use __Auto-Dolly__ mode to move the Virtual Camera to a position on the path tha
 
 | **Property:** || **Function:** |
 |:---|:---|:---|
-| __Path__ || The path that the camera moves along. This property must refer to a  [Cinemachine Path](CinemachinePath.html) or [Cinemachine Smooth Path](CinemachineSmoothPath.html). |
+| __Path__ || The path that the camera moves along. This property must refer to a  [Cinemachine Path](CinemachinePath.md) or [Cinemachine Smooth Path](CinemachineSmoothPath.md). |
 | __Path Position__ || The position along the path to place the camera. Animate this property directly or enable Auto-Dolly. The value is in the units specified by Position Units. |
 | __Position Units__ || The unit of measure for Path Position.  |
 | | _Path Units_ | Use waypoints along the path. The value 0 represents the first waypoint on the path, 1 is the second waypoint, and so on. |

--- a/Documentation~/CinemachineClearShot.md
+++ b/Documentation~/CinemachineClearShot.md
@@ -2,9 +2,9 @@
 
 The __Cinemachine ClearShot Camera__ component chooses among its children Virtual Cameras for the best quality shot of the target. Use Clear Shot to set up complex multi-camera coverage of a Scene to guarantee a clear view of the target.
 
-This can be a very powerful tool. Virtual Camera children with [Cinemachine Collider](CinemachineCollider.html) extensions analyze the Scene for target obstructions, optimal target distance, and so on. Clear Shot uses this information to choose the best child to activate.
+This can be a very powerful tool. Virtual Camera children with [Cinemachine Collider](CinemachineCollider.md) extensions analyze the Scene for target obstructions, optimal target distance, and so on. Clear Shot uses this information to choose the best child to activate.
 
-**Tip:** To use a single [Cinemachine Collider](CinemachineCollider.html) for all Virtual Camera children, add a Cinemachine Collider extension to the ClearShot GameObject instead of each of its Virtual Camera children. This Cinemachine Collider extension applies to all of the children, as if each of them had that Collider as its own extension.
+**Tip:** To use a single [Cinemachine Collider](CinemachineCollider.md) for all Virtual Camera children, add a Cinemachine Collider extension to the ClearShot GameObject instead of each of its Virtual Camera children. This Cinemachine Collider extension applies to all of the children, as if each of them had that Collider as its own extension.
 
 If multiple child cameras have the same shot quality, the Clear Shot camera chooses the one with the highest priority.
 

--- a/Documentation~/CinemachineCollider.md
+++ b/Documentation~/CinemachineCollider.md
@@ -1,6 +1,6 @@
 # Cinemachine Collider
 
-__Cinemachine Collider__ is an [extension](CinemachineVirtualCameraExtensions.html) for the Cinemachine Virtual Camera. It post-processes the final position of the Virtual Camera to attempt to preserve the line of sight with the __Look At__ target of the Virtual Camera. It does this by moving away from the GameObjects that obstruct the view.
+__Cinemachine Collider__ is an [extension](CinemachineVirtualCameraExtensions.md) for the Cinemachine Virtual Camera. It post-processes the final position of the Virtual Camera to attempt to preserve the line of sight with the __Look At__ target of the Virtual Camera. It does this by moving away from the GameObjects that obstruct the view.
 
 Add a Cinemachine Collider extension to a Cinemachine Virtual Camera to do any of the following tasks:
 
@@ -8,7 +8,7 @@ Add a Cinemachine Collider extension to a Cinemachine Virtual Camera to do any o
 
 * Place the camera in front of obstacles that come between the Virtual Camera and its __Look At__ target.
 
-* Evaluate shot quality. __Shot quality__ is a measure of the distance of the Virtual Camera from its ideal position, the distance of the Virtual Camera to its target, and the obstacles that block the view of the target. Other modules use shot quality, including [Clear Shot](CinemachineClearShot.html).
+* Evaluate shot quality. __Shot quality__ is a measure of the distance of the Virtual Camera from its ideal position, the distance of the Virtual Camera to its target, and the obstacles that block the view of the target. Other modules use shot quality, including [Clear Shot](CinemachineClearShot.md).
 
 The Collider uses a [Physics Raycaster](https://docs.unity3d.com/Manual/script-PhysicsRaycaster.html). Therefore, Cinemachine Collider requires that potential obstacles have [collider](https://docs.unity3d.com/Manual/CollidersOverview.html) volumes. There is a performance cost for this requirement. If this cost is prohibitive in your game, consider implementing this functionality in a different way.
 

--- a/Documentation~/CinemachineColliderConfiner.md
+++ b/Documentation~/CinemachineColliderConfiner.md
@@ -2,6 +2,6 @@
 
 As characters and objects move around in a complex Scene, obstacles in the Scene sometimes come between a camera and its target.  Similarly, you might need to move a camera to a position in the Scene that another GameObject already occupies. Cinemachine provides extensions to handle these situations:
 
-* [Cinemachine Collider](CinemachineCollider.html)
-* [Cinemachine Confiner](CinemachineConfiner.html)
+* [Cinemachine Collider](CinemachineCollider.md)
+* [Cinemachine Confiner](CinemachineConfiner.md)
 

--- a/Documentation~/CinemachineConfiner.md
+++ b/Documentation~/CinemachineConfiner.md
@@ -1,6 +1,6 @@
 # Cinemachine Confiner
 
-Use the __Cinemachine Confiner__ [extension](CinemachineVirtualCameraExtensions.html) to limit the camera’s position to a volume or area.
+Use the __Cinemachine Confiner__ [extension](CinemachineVirtualCameraExtensions.md) to limit the camera’s position to a volume or area.
 
 Confier operates in 2D or 3D mode.  The mode influences the kind of bounding shape it accepts. In 3D mode, the camera’s position in 3D is confined to a volume.  This also works for 2D games, but you need to take the depth into account.  In 2D mode, you don’t have to worry about depth.
 

--- a/Documentation~/CinemachineFollowZoom.md
+++ b/Documentation~/CinemachineFollowZoom.md
@@ -1,6 +1,6 @@
 # Cinemachine Follow Zoom
 
-This [extension](CinemachineVirtualCameraExtensions.html) adjusts the FOV of the lens to keep the target object at a constant size on the screen, regardless of camera and target position.
+This [extension](CinemachineVirtualCameraExtensions.md) adjusts the FOV of the lens to keep the target object at a constant size on the screen, regardless of camera and target position.
 
 ## Properties:
 

--- a/Documentation~/CinemachineFreeLook.md
+++ b/Documentation~/CinemachineFreeLook.md
@@ -4,13 +4,13 @@ The __Cinemachine Free Look Camera__ component provides a third-person camera ex
 
 ![Cinemachine Free Look in the Scene window](images/CinemachineFreelook.png)
 
-Each rig defines a ring around the target, with its own radius, height offset, composer, lens properties, and Noise settings. These are the same as the [properties for a regular Virtual Camera](CinemachineVirtualCamera.html).
+Each rig defines a ring around the target, with its own radius, height offset, composer, lens properties, and Noise settings. These are the same as the [properties for a regular Virtual Camera](CinemachineVirtualCamera.md).
 
 Cinemachine Free Look Camera also defines a spline that connects the rigs. The spline defines the camera’s position when blending between the rigs.
 
 ![Cinemachine Free Look properties for spline, and the __Top__, __Middle__, and __Bottom__ rigs](images/CinemachineFreeLookProperties.png)
 
-Free Look uses player input along the x and y axes. The x axis controls the orbital position along the __Top__, __Middle__, or __Bottom__ horizontal orbits, like the [Orbital Transposer](CinemachineBodyOrbitalTransposer.html). The y-axis controls the vertical position, using the spline to determine the position between rigs.
+Free Look uses player input along the x and y axes. The x axis controls the orbital position along the __Top__, __Middle__, or __Bottom__ horizontal orbits, like the [Orbital Transposer](CinemachineBodyOrbitalTransposer.md). The y-axis controls the vertical position, using the spline to determine the position between rigs.
 
 ## Properties:
 
@@ -18,10 +18,10 @@ Free Look uses player input along the x and y axes. The x axis controls the orbi
 |:---|:---|:---|
 | __Solo__ || Toggles whether or not the Virtual Camera is temporarily live. Use this property to get immediate visual feedback in the [Game view](https://docs.unity3d.com/Manual/GameView.html) to adjust the Virtual Camera. |
 | __Game Window Guides__ || Toggles the visibility of compositional guides in the Game view. These guides are available when Look At specifies a GameObject and the Aim section uses Composer or Group Composer, or when Follow specifies a target and the Body section uses Framing Composer. This property applies to all Virtual Cameras. |
-| __Save During Play__ || Check to [apply the changes while in Play mode](CinemachineSavingDuringPlay.html).  Use this feature to fine-tune a Virtual Camera without having to remember which properties to copy and paste. This property applies to all Virtual Cameras. |
+| __Save During Play__ || Check to [apply the changes while in Play mode](CinemachineSavingDuringPlay.md).  Use this feature to fine-tune a Virtual Camera without having to remember which properties to copy and paste. This property applies to all Virtual Cameras. |
 | __Priority__ || The importance of this Virtual Camera for choosing the next shot. A higher value indicates a higher priority. Cinemachine Brain chooses the next live Virtual Camera from all Virtual Cameras that are activated and have the same or higher priority as the current live Virtual Camera. This property has no effect when using a Virtual Camera with Timeline. |
-| __Follow__ || The target GameObject to move with. The [Body properties](CinemachineVirtualCameraBody.html) use this target to update the position of the Unity camera. |
-| __Look At__ || The target GameObject to aim at. The [Aim properties](CinemachineVirtualCameraAim.html) use this target to update the rotation of the Unity camera. This property is normally the same as the Follow target. |
+| __Follow__ || The target GameObject to move with. The [Body properties](CinemachineVirtualCameraBody.md) use this target to update the position of the Unity camera. |
+| __Look At__ || The target GameObject to aim at. The [Aim properties](CinemachineVirtualCameraAim.md) use this target to update the rotation of the Unity camera. This property is normally the same as the Follow target. |
 | __Common Lens__ || Check to apply a common lens setting to all three child rigs. Uncheck to use separate lens settings for each child rig. |
 | __Lens__ || If Common Lens is checked, these lens settings apply to all three rigs. These properties mirror their counterparts in the property settings for the [Unity camera](https://docs.unity3d.com/Manual/class-Camera.html). |
 | | _Field Of View_ | This is the camera view in vertical degrees. For example, to specify the equivalent of a 50mm lens on a Super 35 sensor, enter a Field of View of 19.6 degrees. This property is available when the Unity camera with the Cinemachine Brain component uses a Projection of Perspective.   |

--- a/Documentation~/CinemachineManagerCameras.md
+++ b/Documentation~/CinemachineManagerCameras.md
@@ -4,15 +4,15 @@ A __manager__ camera oversees many Virtual Cameras but acts as a single Virtual 
 
 Cinemachine includes these manager cameras:
 
-* [Free Look Camera](CinemachineFreeLook.html): an enhanced [Orbital Transposer](CinemachineBodyOrbitalTransposer.html). It manages three horizontal orbits, arranged vertically to surround an avatar.
+* [Free Look Camera](CinemachineFreeLook.md): an enhanced [Orbital Transposer](CinemachineBodyOrbitalTransposer.md). It manages three horizontal orbits, arranged vertically to surround an avatar.
 
-* [Mixing Camera](CinemachineMixingCamera.html): uses the weighted average of up to eight child Virtual Cameras.
+* [Mixing Camera](CinemachineMixingCamera.md): uses the weighted average of up to eight child Virtual Cameras.
 
-* [Blend List Camera](CinemachineBlendListCamera.html): executes a sequence of blends or cuts of its child Virtual Cameras.
+* [Blend List Camera](CinemachineBlendListCamera.md): executes a sequence of blends or cuts of its child Virtual Cameras.
 
-* [Clear Shot Camera](CinemachineClearShot.html): picks the child Virtual Camera with the best view of the target.
+* [Clear Shot Camera](CinemachineClearShot.md): picks the child Virtual Camera with the best view of the target.
 
-* [State-Driven Camera](CinemachineStateDrivenCamera.html): picks a child Virtual Camera in reaction to changes in animation state.
+* [State-Driven Camera](CinemachineStateDrivenCamera.md): picks a child Virtual Camera in reaction to changes in animation state.
 
 Because manager cameras act like normal Virtual Cameras, you can nest them. In other words, create arbitrarily complex camera rigs that combine regular Virtual Cameras and manager cameras.
 

--- a/Documentation~/CinemachineOverview.md
+++ b/Documentation~/CinemachineOverview.md
@@ -32,11 +32,11 @@ One Virtual Camera has control of the Unity camera at any point in time. This is
 
 The Cinemachine Brain is a component in the Unity Camera itself. Cinemachine Brain monitors all active Virtual Cameras in the Scene. To specify the next live Virtual Camera, you [activate or deactivate](https://docs.unity3d.com/Manual/DeactivatingGameObjects.html) the desired Virtual Camera's game object. Cinemachine Brain then chooses the most recently activated Virtual Camera with the same or higher priority as the live Virtual Camera.  It performs a cut or blend between the previous and new Virtual Cameras.
 
-**Tip**: Use Cinemachine Brain to respond to dynamic game events in real time. It allows your game logic to control the camera by manipulating priorities. This is particularly useful for live gameplay, where action isn’t always predictable. Use [Timeline](CinemachineTimeline.html) to choreograph cameras in predictable situations, like cutscenes. Timeline overrides the Cinemachine Brain priority system to give you precise, to-the-frame camera control.
+**Tip**: Use Cinemachine Brain to respond to dynamic game events in real time. It allows your game logic to control the camera by manipulating priorities. This is particularly useful for live gameplay, where action isn’t always predictable. Use [Timeline](CinemachineTimeline.md) to choreograph cameras in predictable situations, like cutscenes. Timeline overrides the Cinemachine Brain priority system to give you precise, to-the-frame camera control.
 
 ## Moving and aiming
 
-Use the [__Body__ properties](CinemachineVirtualCameraBody.html) in a Virtual Camera to specify how to move it in the Scene. Use the [__Aim__ properties](CinemachineVirtualCameraAim.html) to specify how to rotate it.
+Use the [__Body__ properties](CinemachineVirtualCameraBody.md) in a Virtual Camera to specify how to move it in the Scene. Use the [__Aim__ properties](CinemachineVirtualCameraAim.md) to specify how to rotate it.
 
 A Virtual Camera has two targets:
 
@@ -66,7 +66,7 @@ The __Aim__ properties offer the following procedural algorithms for rotating a 
 
 ## Composing a shot
 
-The [__Framing Transposer__](CinemachineBodyFramingTransposer.html), [__Composer__](CinemachineAimComposer.html), and [__Group Composer__](CinemachineAimGroupComposer.html) algorithms define areas in the camera frame for you to compose a shot:
+The [__Framing Transposer__](CinemachineBodyFramingTransposer.md), [__Composer__](CinemachineAimComposer.md), and [__Group Composer__](CinemachineAimGroupComposer.md) algorithms define areas in the camera frame for you to compose a shot:
 
 * __Dead zone__: The area of the frame that Cinemachine keeps the target in.
 
@@ -86,6 +86,6 @@ Adjust these areas to get a wide range of camera behaviors. To do this, drag the
 
 ## Using noise to simulate camera shake
 
-Real-world physical cameras are often heavy and cumbersome. They are hand-held by the camera operator or mounted on unstable objects like moving vehicles. Use [Noise properties](CinemachineVirtualCameraNoise.html) to simulate these real-world qualities for cinematic effect. For example, you could add a camera shake when following a running character to immerse the player in the action.
+Real-world physical cameras are often heavy and cumbersome. They are hand-held by the camera operator or mounted on unstable objects like moving vehicles. Use [Noise properties](CinemachineVirtualCameraNoise.md) to simulate these real-world qualities for cinematic effect. For example, you could add a camera shake when following a running character to immerse the player in the action.
 
 At each frame update, Cinemachine adds noise separately from the movement of the camera to follow a target. Noise does not influence the camera’s position in future frames. This separation ensures that properties like __damping__ behave as expected.

--- a/Documentation~/CinemachinePostProcessing.md
+++ b/Documentation~/CinemachinePostProcessing.md
@@ -1,6 +1,6 @@
 # Cinemachine and Postprocessing
 
-Use the Cinemachine Post Processing [extension](CinemachineVirtualCameraExtensions.html) to attach a Postprocessing V2 profile to a Virtual Camera.
+Use the Cinemachine Post Processing [extension](CinemachineVirtualCameraExtensions.md) to attach a Postprocessing V2 profile to a Virtual Camera.
 
 **Note**: Unity recommends using Postprocessing V2 instead of Postprocessing V1.
 

--- a/Documentation~/CinemachineSetUpVCam.md
+++ b/Documentation~/CinemachineSetUpVCam.md
@@ -4,13 +4,13 @@ In your project, organize your Scene Hierarchy to have a single Unity camera wit
 
 To add a Virtual Camera to a Scene:
 
-1. In the Unity menu, choose __Cinemachine > Create Virtual Camera__. <br/>Unity adds a new GameObject with a Cinemachine Virtual Camera component. If necessary, Unity also adds a [Cinemachine Brain](CinemachineBrainProperties.html) component to the Unity camera GameObject for you.
+1. In the Unity menu, choose __Cinemachine > Create Virtual Camera__. <br/>Unity adds a new GameObject with a Cinemachine Virtual Camera component. If necessary, Unity also adds a [Cinemachine Brain](CinemachineBrainProperties.md) component to the Unity camera GameObject for you.
 
 2. Use the __Follow__ property to specify a GameObject to follow. <br/>The Virtual Camera automatically positions the Unity camera relative to this GameObject at all times, even as you move it in the Scene.
 
 3. Use the __Look At__ property to specify the GameObject that the Virtual Camera should aim at. <br/>The Virtual Camera automatically rotates the Unity camera to face this GameObject at all times, even as you move it in the Scene.
 
-4. [Customize the Virtual Camera](CinemachineVirtualCamera.html) as needed. <br/>Choose the algorithm for following and looking at, and adjust settings such as the follow offset, the follow damping, the screen composition, and the damping used when re-aiming the camera.
+4. [Customize the Virtual Camera](CinemachineVirtualCamera.md) as needed. <br/>Choose the algorithm for following and looking at, and adjust settings such as the follow offset, the follow damping, the screen composition, and the damping used when re-aiming the camera.
 
 ![Adding a Virtual Camera to a Scene. Note the Cinemachine Brain icon next to the Main Camera.](images/CinemachineNewVCam.png)
 

--- a/Documentation~/CinemachineStoryboard.md
+++ b/Documentation~/CinemachineStoryboard.md
@@ -1,6 +1,6 @@
 # Storyboard
 
-Use the Cinemachine Storyboard [extension](CinemachineVirtualCameraExtensions.html) to let artists, producers, and directors contribute to your game development. Cinemachine Storyboard places a still image in screen space over the output of the Unity camera.
+Use the Cinemachine Storyboard [extension](CinemachineVirtualCameraExtensions.md) to let artists, producers, and directors contribute to your game development. Cinemachine Storyboard places a still image in screen space over the output of the Unity camera.
 
 Storyboard simplifies animatics for your team. Start with still images to pre-visualize terrain, layout, movement, lighting, timing, and so on. Following the intentions of the Storyboard image, developers incrementally add the assets, GameObjects, and settings that implement the Scene.
 
@@ -21,5 +21,5 @@ Use the properties in the Storyboard component to hide and show the image to com
 | __Rotation__ || The screen-space rotation of the image. |
 | __Scale__ || The screen-space scaling of the image. |
 | __Sync Scale__ || Check to synchronize the scale of the x and y axes. |
-| __Mute Camera__ || Check to prevent the Virtual Camera from updating the position, rotation, or scale of the Unity camera. Use this feature to prevent Timeline from [blending](CinemachineBlending.html) the camera to an unintended position in the Scene. |
+| __Mute Camera__ || Check to prevent the Virtual Camera from updating the position, rotation, or scale of the Unity camera. Use this feature to prevent Timeline from [blending](CinemachineBlending.md) the camera to an unintended position in the Scene. |
 | __Split View__ || Wipe the image on and off horizontally. |

--- a/Documentation~/CinemachineTargetGroup.md
+++ b/Documentation~/CinemachineTargetGroup.md
@@ -1,6 +1,6 @@
 # Cinemachine Target Group
 
-Use Cinemachine Target Group to treat multiple GameObjects as a single Look At target. Use a Target Group with the [Group Composer](CinemachineAimGroupComposer.html) algorithm.
+Use Cinemachine Target Group to treat multiple GameObjects as a single Look At target. Use a Target Group with the [Group Composer](CinemachineAimGroupComposer.md) algorithm.
 
 To create a Virtual Camera with a Target Group:
 

--- a/Documentation~/CinemachineTimeline.md
+++ b/Documentation~/CinemachineTimeline.md
@@ -2,9 +2,9 @@
 
 Use [Timeline](https://docs.unity3d.com/Manual/TimelineSection.html) to activate, deactivate, and blend between Virtual Cameras. In Timeline, combine Cinemachine with other GameObjects and assets to interactively implement and tune rich cutscenes, even interactive ones.
 
-**Tip**: For simple shot sequences, use a [Cinemachine Blend List Camera](CinemachineBlendListCamera.html) instead of Timeline.
+**Tip**: For simple shot sequences, use a [Cinemachine Blend List Camera](CinemachineBlendListCamera.md) instead of Timeline.
 
-Timeline overrides the priority-based decisions made by [Cinemachine Brain](CinemachineBrainProperties.html). When the timeline finishes, control returns to the Cinemachine Brain, which chooses the Virtual Camera with the highest Priority setting.
+Timeline overrides the priority-based decisions made by [Cinemachine Brain](CinemachineBrainProperties.md). When the timeline finishes, control returns to the Cinemachine Brain, which chooses the Virtual Camera with the highest Priority setting.
 
 You control Virtual Cameras in Timeline with a __Cinemachine Shot Clip__. Each shot clip points to a Virtual Camera to activate then deactivate. Use a sequence of shot clips to specify the order and duration of each shot.
 
@@ -40,7 +40,7 @@ To add Cinemachine Shot Clips to a Cinemachine Track:
 
 3. In the Timeline editor, adjust the order, duration, cutting, and blending of the shot clip.
 
-4. [Adjust the properties of the Virtual Camera](CinemachineVirtualCamera.html) to place it in the Scene and specify what to aim at or follow.
+4. [Adjust the properties of the Virtual Camera](CinemachineVirtualCamera.md) to place it in the Scene and specify what to aim at or follow.
 
 5. To animate properties of the Virtual Camera, create an [Animation Track](https://docs.unity3d.com/Manual/TimelineAnimationTrackProperties.html) for it and animate as you would any other GameObject.
 

--- a/Documentation~/CinemachineTopDown.md
+++ b/Documentation~/CinemachineTopDown.md
@@ -4,5 +4,5 @@ Cinemachine Virtual Cameras are modeled after human camera operators and how the
 
 **Tip:** You can deliberately roll by animating properties like __Dutch__ in a Virtual Camera.
 
-If you are building a top-down game where the cameras look straight down, the best practice is to redefine the up direction, for the purposes of the camera.  You do this by setting the __World Up Override__ in the [Cinemachine Brain](CinemachineBrainProperties.html) to a GameObject whose local up points in the direction that you want the Virtual Camera’s up to normally be.   This is applied to all Virtual Cameras controlled by that Brain.
+If you are building a top-down game where the cameras look straight down, the best practice is to redefine the up direction, for the purposes of the camera.  You do this by setting the __World Up Override__ in the [Cinemachine Brain](CinemachineBrainProperties.md) to a GameObject whose local up points in the direction that you want the Virtual Camera’s up to normally be.   This is applied to all Virtual Cameras controlled by that Brain.
 

--- a/Documentation~/CinemachineVirtualCamera.md
+++ b/Documentation~/CinemachineVirtualCamera.md
@@ -2,7 +2,7 @@
 
 The Cinemacine Virtual Camera is a component that you add to an empty GameObject. It represents a Virtual Camera in the Unity Scene.
 
-Use the __Aim__, __Body__, and __Noise__ properties to specify how the Virtual Camera animates position, rotation, and other properties. The Virtual Camera applies these settings to the Unity Camera when [Cinemachine Brain](CinemachineBrainProperties.html) or [Timeline](CinemachineTimeline.html) transfers control of the Unity camera to the Virtual Camera.
+Use the __Aim__, __Body__, and __Noise__ properties to specify how the Virtual Camera animates position, rotation, and other properties. The Virtual Camera applies these settings to the Unity Camera when [Cinemachine Brain](CinemachineBrainProperties.md) or [Timeline](CinemachineTimeline.md) transfers control of the Unity camera to the Virtual Camera.
 
 At any time, each Virtual Camera may be in one of these states:
 
@@ -20,10 +20,10 @@ At any time, each Virtual Camera may be in one of these states:
 |:---|:---|:---|
 | __Solo__ || Toggles whether or not the Virtual Camera is temporarily live. Use this property to get immediate visual feedback in the [Game view](https://docs.unity3d.com/Manual/GameView.html) to adjust the Virtual Camera. |
 | __Game Window Guides__ || Toggles the visibility of compositional guides in the Game view. These guides are available when Look At specifies a GameObject and the Aim section uses Composer or Group Composer, or when Follow specifies a target and the Body section uses Framing Composer. This property applies to all Virtual Cameras. |
-| __Save During Play__ || Check to [apply the changes while in Play mode](CinemachineSavingDuringPlay.html).  Use this feature to fine-tune a Virtual Camera without having to remember which properties to copy and paste. This property applies to all Virtual Cameras. |
+| __Save During Play__ || Check to [apply the changes while in Play mode](CinemachineSavingDuringPlay.md).  Use this feature to fine-tune a Virtual Camera without having to remember which properties to copy and paste. This property applies to all Virtual Cameras. |
 | __Priority__ || The importance of this Virtual Camera for choosing the next shot. A higher value indicates a higher priority. Cinemachine Brain chooses the next live Virtual Camera from all Virtual Cameras that are activated and have the same or higher priority as the current live Virtual Camera. This property has no effect when using a Virtual Camera with Timeline. |
-| __Follow__ || The target GameObject that the Virtual Camera moves with. The [Body properties](CinemachineVirtualCameraBody.html) use this target to update the position of the Unity camera. Keep this property empty to make the Unity camera use the position of the Virtual Camera’ transform. For example, you might choose to animate the Virtual Camera in Timeline. |
-| __Look At__ || The target GameObject to aim the Unity camera at. The [Aim properties](CinemachineVirtualCameraAim.html) use this target to update the rotation of the Unity camera. Keep this property empty to make the Unity camera use the orientation of the Virtual Camera. |
+| __Follow__ || The target GameObject that the Virtual Camera moves with. The [Body properties](CinemachineVirtualCameraBody.md) use this target to update the position of the Unity camera. Keep this property empty to make the Unity camera use the position of the Virtual Camera’ transform. For example, you might choose to animate the Virtual Camera in Timeline. |
+| __Look At__ || The target GameObject to aim the Unity camera at. The [Aim properties](CinemachineVirtualCameraAim.md) use this target to update the rotation of the Unity camera. Keep this property empty to make the Unity camera use the orientation of the Virtual Camera. |
 | __Position Blending__ || Style for blending positions to and from this Virtual Camera. |
 | | _Linear_ | Standard linear position blend. |
 | | _Spherical_ | Spherical blend about the Look At position, if there is a Look At target. |
@@ -36,6 +36,6 @@ At any time, each Virtual Camera may be in one of these states:
 | | _Far Clip Plane_ | The furthest point relative to the camera where drawing occurs. |
 | __Dutch__ || Dutch angle. Tilts the Unity camera on the z-axis, in degrees. This property is unique to the Virtual Camera; there is no counterpart property in the Unity camera. |
 | __Extensions__ || Components that add extra behaviors to the Virtual Camera.  |
-| | _Add Extension_ | Choose a new [extension](CinemachineVirtualCameraExtensions.html) to add to the Virtual Camera. |
+| | _Add Extension_ | Choose a new [extension](CinemachineVirtualCameraExtensions.md) to add to the Virtual Camera. |
 
 

--- a/Documentation~/CinemachineVirtualCameraAim.md
+++ b/Documentation~/CinemachineVirtualCameraAim.md
@@ -1,18 +1,18 @@
 # Aim properties
 
-Use the Aim properties to specify how to rotate the Virtual Camera. To change the camera’s position, use the [Body properties](CinemachineVirtualCameraBody.html).
+Use the Aim properties to specify how to rotate the Virtual Camera. To change the camera’s position, use the [Body properties](CinemachineVirtualCameraBody.md).
 
 ![Aim properties, with the Composer algorithm (red)](images/CinemachineAim.png)
 
-* [__Composer__](CinemachineAimComposer.html): Keep the __Look At__ target in the camera frame.
+* [__Composer__](CinemachineAimComposer.md): Keep the __Look At__ target in the camera frame.
 
-* [__Group Composer__](CinemachineAimGroupComposer.html): Keep multiple __Look At__ targets in the camera frame.
+* [__Group Composer__](CinemachineAimGroupComposer.md): Keep multiple __Look At__ targets in the camera frame.
 
-* [__Do Nothing__](CinemachineAimDoNothing.html): Do not procedurally rotate the Virtual Camera.
+* [__Do Nothing__](CinemachineAimDoNothing.md): Do not procedurally rotate the Virtual Camera.
 
-* [__POV__](CinemachineAimPOV.html): Rotate the Virtual Camera based on the user’s input.
+* [__POV__](CinemachineAimPOV.md): Rotate the Virtual Camera based on the user’s input.
 
-* [__Same As Follow Target__](CinemachineAimSameAsFollow.html): Set the camera’s rotation to the rotation of the __Follow__ target.
+* [__Same As Follow Target__](CinemachineAimSameAsFollow.md): Set the camera’s rotation to the rotation of the __Follow__ target.
 
-* [__Hard Look At__](CinemachineAimHardLook.html): Keep the __Look At__ target in the center of the camera frame.
+* [__Hard Look At__](CinemachineAimHardLook.md): Keep the __Look At__ target in the center of the camera frame.
 

--- a/Documentation~/CinemachineVirtualCameraBody.md
+++ b/Documentation~/CinemachineVirtualCameraBody.md
@@ -1,14 +1,14 @@
 # Body properties
 
-Use the Body properties to specify the algorithm that moves the Virtual Camera in the Scene. To rotate the camera, set the [Aim properties](CinemachineVirtualCameraAim.html).
+Use the Body properties to specify the algorithm that moves the Virtual Camera in the Scene. To rotate the camera, set the [Aim properties](CinemachineVirtualCameraAim.md).
 
 ![__Body__ properties, with the __Transposer__ algorithm (red)](images/CinemachineBody.png)
 
 Cinemachine includes these algorithms for moving a Virtual Camera:
 
-* [__Transposer__](CinemachineBodyTransposer.html): moves in a fixed relationship to the __Follow__ target.
-* [__Do Nothing__](CinemachineBodyDoNothing.html): does not move the Virtual Camera.
-* [__Framing Transposer__](CinemachineBodyFramingTransposer.html): moves in a fixed screen-space relationship to the __Follow__ target.
-* [__Orbital Transposer__](CinemachineBodyOrbitalTransposer.html): moves in a variable relationship to the __Follow__ target, optionally accepting player input.
-* [__Tracked Dolly__](CinemachineBodyTrackedDolly.html): moves along a predefined path.
-* [__Hard Lock to Target__](CinemachineBodyHardLockTarget.html): uses the same position at the __Follow__ target.
+* [__Transposer__](CinemachineBodyTransposer.md): moves in a fixed relationship to the __Follow__ target.
+* [__Do Nothing__](CinemachineBodyDoNothing.md): does not move the Virtual Camera.
+* [__Framing Transposer__](CinemachineBodyFramingTransposer.md): moves in a fixed screen-space relationship to the __Follow__ target.
+* [__Orbital Transposer__](CinemachineBodyOrbitalTransposer.md): moves in a variable relationship to the __Follow__ target, optionally accepting player input.
+* [__Tracked Dolly__](CinemachineBodyTrackedDolly.md): moves along a predefined path.
+* [__Hard Lock to Target__](CinemachineBodyHardLockTarget.md): uses the same position at the __Follow__ target.

--- a/Documentation~/CinemachineVirtualCameraExtensions.md
+++ b/Documentation~/CinemachineVirtualCameraExtensions.md
@@ -1,6 +1,6 @@
 # Extensions
 
-Extensions are components that add more sophisticated behaviors to a Virtual Camera. For example, the [Collider](CinemachineCollider.html) extension moves a camera out of the way of GameObjects that obstruct the camera’s view of its target.
+Extensions are components that add more sophisticated behaviors to a Virtual Camera. For example, the [Collider](CinemachineCollider.md) extension moves a camera out of the way of GameObjects that obstruct the camera’s view of its target.
 
 Cinemachine includes a variety of extensions. Create your own custom extensions by deriving from the `CinemachineExtension` class.
 

--- a/Documentation~/CinemachineVirtualCameraNoise.md
+++ b/Documentation~/CinemachineVirtualCameraNoise.md
@@ -4,7 +4,7 @@ Use Noise properties in a Virtual Camera to simulate camera shake. Cinemachine i
 
 ![Choosing the Basic Multi Channel Perlin component to add camera noise](images/CinemachineBasicMultiChannelPerlin.png)
 
-The Basic Multi Channel Perlin component applies a noise profile. A noise profile is an Asset that defines the behavior of noise over time. Cinemachine includes a few noise profile assets. You can [edit these and create your own](CinemachineNoiseProfiles.html).
+The Basic Multi Channel Perlin component applies a noise profile. A noise profile is an Asset that defines the behavior of noise over time. Cinemachine includes a few noise profile assets. You can [edit these and create your own](CinemachineNoiseProfiles.md).
 
 To apply noise:
 
@@ -12,7 +12,7 @@ To apply noise:
 
 2. In the [Inspector](https://docs.unity3d.com/Manual/UsingTheInspector.html), use the  __Noise__ drop-down menu to choose __Basic Multi Channel Perlin__.
 
-3. In __Noise Profile__, choose an existing profile asset or [create your own profile](CinemachineNoiseProfiles.html).
+3. In __Noise Profile__, choose an existing profile asset or [create your own profile](CinemachineNoiseProfiles.md).
 
 4. Use __Amplitude Gain__ and __Frequency Gain__ to fine-tune the noise.
 

--- a/Documentation~/index.md
+++ b/Documentation~/index.md
@@ -8,7 +8,7 @@ The procedural nature of these modules makes Cinemachine bug-resistant. When you
 
 Cinemachine works in real time across all genres including FPS, third person, 2D, side-scroller, top down, and RTS. It supports as many shots in your Scene as you need. Its modular system lets you compose sophisticated behaviors.
 
-Cinemachine works well with other Unity tools, acting as a powerful complement to Timeline, animation, and post-processing assets.  Create your own [extensions](CinemachineVirtualCameraExtensions.html) or integrate it with your custom camera scripts.
+Cinemachine works well with other Unity tools, acting as a powerful complement to Timeline, animation, and post-processing assets.  Create your own [extensions](CinemachineVirtualCameraExtensions.md) or integrate it with your custom camera scripts.
 
 ## Requirements
 


### PR DESCRIPTION
Noticed that the links to the filename.html is sent to 404 error. Fixed on filename.md
For example: [before](https://github.com/Unity-Technologies/upm-package-cinemachine/blob/master/Documentation%7E/CinemachineFollowZoom.html) and [after](https://github.com/Unity-Technologies/upm-package-cinemachine/blob/master/Documentation~/CinemachineFollowZoom.md)