### PR TITLE
Updated the Pixel Perfect extension to also support the standalone package.

### DIFF
--- a/Runtime/Behaviours/CinemachinePixelPerfect.cs
+++ b/Runtime/Behaviours/CinemachinePixelPerfect.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-#if CINEMACHINE_LWRP_7_1_3 || CINEMACHINE_PIXEL_PERFECT_2_1_0
+#if CINEMACHINE_LWRP_7_1_3 || CINEMACHINE_PIXEL_PERFECT_2_0_3
 
 namespace Cinemachine
 {
@@ -30,7 +30,7 @@ namespace Cinemachine
 
 #if CINEMACHINE_LWRP_7_1_3
             UnityEngine.Experimental.Rendering.Universal.PixelPerfectCamera pixelPerfectCamera;
-#elif CINEMACHINE_PIXEL_PERFECT_2_1_0
+#elif CINEMACHINE_PIXEL_PERFECT_2_0_3
             UnityEngine.U2D.PixelPerfectCamera pixelPerfectCamera;
 #endif
             brain.TryGetComponent(out pixelPerfectCamera);

--- a/Runtime/Behaviours/CinemachinePixelPerfect.cs
+++ b/Runtime/Behaviours/CinemachinePixelPerfect.cs
@@ -1,7 +1,6 @@
 ﻿using UnityEngine;
 
-#if CINEMACHINE_LWRP_7_1_3
-using UnityEngine.Experimental.Rendering.Universal
+#if CINEMACHINE_LWRP_7_1_3 || CINEMACHINE_PIXEL_PERFECT_2_1_0
 
 namespace Cinemachine
 {
@@ -13,7 +12,7 @@ namespace Cinemachine
     /// </summary>
     [AddComponentMenu("")] // Hide in menu
     [ExecuteAlways]
-    public class CinemachineUniversalPixelPerfect : CinemachineExtension
+    public class CinemachinePixelPerfect : CinemachineExtension
     {
         protected override void PostPipelineStageCallback(
             CinemachineVirtualCameraBase vcam,
@@ -29,7 +28,11 @@ namespace Cinemachine
             if (brain == null || !brain.IsLive(vcam))
                 return;
 
-            PixelPerfectCamera pixelPerfectCamera;
+#if CINEMACHINE_LWRP_7_1_3
+            UnityEngine.Experimental.Rendering.Universal.PixelPerfectCamera pixelPerfectCamera;
+#elif CINEMACHINE_PIXEL_PERFECT_2_1_0
+            UnityEngine.U2D.PixelPerfectCamera pixelPerfectCamera;
+#endif
             brain.TryGetComponent(out pixelPerfectCamera);
             if (pixelPerfectCamera == null || !pixelPerfectCamera.isActiveAndEnabled)
                 return;
@@ -57,6 +60,6 @@ namespace Cinemachine
     /// sprites would appear pixel perfect when the virtual camera becomes live.
     /// </summary>
     [AddComponentMenu("")] // Hide in menu
-    public class CinemachineUniversalPixelPerfect : MonoBehaviour {}
+    public class CinemachinePixelPerfect : MonoBehaviour {}
 }
 #endif

--- a/Runtime/Behaviours/CinemachinePixelPerfect.cs.meta
+++ b/Runtime/Behaviours/CinemachinePixelPerfect.cs.meta
@@ -4,7 +4,7 @@ MonoImporter:
   externalObjects: {}
   serializedVersion: 2
   defaultReferences: []
-  executionOrder: 50
+  executionOrder: -1
   icon: {fileID: 2800000, guid: b8ba3923a6094cd48b85425f47fd7450, type: 3}
   userData: 
   assetBundleName: 

--- a/Runtime/com.unity.cinemachine.asmdef
+++ b/Runtime/com.unity.cinemachine.asmdef
@@ -6,7 +6,8 @@
         "Unity.RenderPipelines.Core.Runtime",
         "Unity.RenderPipelines.HighDefinition.Runtime",
         "Unity.ugui",
-        "Unity.RenderPipelines.Universal.Runtime"
+        "Unity.RenderPipelines.Universal.Runtime",
+        "Unity.2D.PixelPerfect"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -65,6 +66,11 @@
             "name": "com.unity.render-pipelines.universal",
             "expression": "7.1.3",
             "define": "CINEMACHINE_LWRP_7_1_3"
+        },
+        {
+            "name": "com.unity.2d.pixel-perfect",
+            "expression": "2.1.0",
+            "define": "CINEMACHINE_PIXEL_PERFECT_2_1_0"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/com.unity.cinemachine.asmdef
+++ b/Runtime/com.unity.cinemachine.asmdef
@@ -69,8 +69,8 @@
         },
         {
             "name": "com.unity.2d.pixel-perfect",
-            "expression": "2.1.0",
-            "define": "CINEMACHINE_PIXEL_PERFECT_2_1_0"
+            "expression": "2.0.3",
+            "define": "CINEMACHINE_PIXEL_PERFECT_2_0_3"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
Now that the extension is moved to CM itself, it needs to support both the standalone pixel perfect package and URP. If both pixel perfect package and URP are installed in the same project (which should not happen as they don't work together), the Pixel Perfect Camera in URP will have the priority.

As this PR adds an optional dependency of Pixel Perfect package to CM, I'll update the PP package so that we don't run into the same circular dependency issue with URP.