### PR TITLE
Fixed leak reported on the forum

### DIFF
--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -187,6 +187,13 @@ namespace Cinemachine
         {
             for (int i = 0; i < mAllCameras.Count; ++i)
                 mAllCameras[i].Remove(vcam);
+
+            mUpdateStatus.Remove(vcam);
+
+            if (mRoundRobinVcamLastFrame == vcam)
+            {
+                mRoundRobinVcamLastFrame = null;
+            }
         }
 
         CinemachineVirtualCameraBase mRoundRobinVcamLastFrame = null;
@@ -326,12 +333,12 @@ namespace Cinemachine
                 lastUpdateDeltaTime = -2;
             }
         }
-        static Dictionary<CinemachineVirtualCameraBase, UpdateStatus> mUpdateStatus;
+        Dictionary<CinemachineVirtualCameraBase, UpdateStatus> mUpdateStatus;
 
         [RuntimeInitializeOnLoadMethod]
         static void InitializeModule()
         {
-            mUpdateStatus = new Dictionary<CinemachineVirtualCameraBase, UpdateStatus>();
+            CinemachineCore.Instance.mUpdateStatus = new Dictionary<CinemachineVirtualCameraBase, UpdateStatus>();
         }
 
         /// <summary>Internal use only</summary>


### PR DESCRIPTION
Forum post:
https://forum.unity.com/threads/possible-leak.772364/

Dictionary was not cleaned after a camera was deleted.
mRoundRobinVcamLastFrame was not set to null, when the camera it referenced was deleted.

Also, changed static dictionary to non-static. But this does not affect the leak, so if preferred, it can be set back to a static dictionary.