### PR TITLE
NullReferenceException on selecting Cancel while editing Impluse Channel in Cinemachine Impulse source

### DIFF
--- a/Editor/Impulse/CinemachineImpulseChannels.cs
+++ b/Editor/Impulse/CinemachineImpulseChannels.cs
@@ -52,7 +52,11 @@ namespace Cinemachine.Editor
                         AssetDatabase.Refresh();
                     }
                 }
-                sInstance.EnsureDefaultLayer();
+
+                if (sInstance != null)
+                {
+                    sInstance.EnsureDefaultLayer();
+                }
                 return sInstance;
             }
         }


### PR DESCRIPTION
https://fogbugz.unity3d.com/f/cases/1213434

After hitting cancel, sInstance was null. So I added a null-check before accessing it.