### PR TITLE
Game View update on Editor value change - bug 1213819

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Bugfixes
 - Bugfix (1213471, 1213434): add null check in editor
 - Bugfix (1213488): no solo for prefab vcams
+- Bugfix (1213819): RepaintAllViews on editor change
 
 
 ## [2.5.0] - 2020-01-15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ### Bugfixes
 - Bugfix (1213471, 1213434): add null check in editor
 - Bugfix (1213488): no solo for prefab vcams
-- Bugfix (1213819): RepaintAllViews on editor change
+- Bugfix (1213819): repaintGameView on editor change
 
 
 ## [2.5.0] - 2020-01-15

--- a/Editor/Editors/CinemachineStoryboardEditor.cs
+++ b/Editor/Editors/CinemachineStoryboardEditor.cs
@@ -40,8 +40,9 @@ namespace Cinemachine.Editor
                     EditorPrefs.SetBool(kEnabledKey, value);
                     CinemachineStoryboard.s_StoryboardGlobalMute = value;
                     Menu.SetChecked(StoryboardGlobalMuteMenuName, value);
-                    
+#if UNITY_EDITOR
                     UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
+#endif
                 }
             }
         }

--- a/Editor/Editors/CinemachineStoryboardEditor.cs
+++ b/Editor/Editors/CinemachineStoryboardEditor.cs
@@ -42,10 +42,6 @@ namespace Cinemachine.Editor
                     Menu.SetChecked(StoryboardGlobalMuteMenuName, value);
                     
                     UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
-//                    System.Reflection.Assembly assembly = typeof(EditorWindow).Assembly;
-//                    System.Type type = assembly.GetType( "UnityEditor.GameView" );
-//                    var gameview = EditorWindow.GetWindow(type);
-//                    gameview.Repaint();
                 }
             }
         }

--- a/Editor/Editors/CinemachineStoryboardEditor.cs
+++ b/Editor/Editors/CinemachineStoryboardEditor.cs
@@ -40,6 +40,12 @@ namespace Cinemachine.Editor
                     EditorPrefs.SetBool(kEnabledKey, value);
                     CinemachineStoryboard.s_StoryboardGlobalMute = value;
                     Menu.SetChecked(StoryboardGlobalMuteMenuName, value);
+                    
+                    //UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
+                    System.Reflection.Assembly assembly = typeof(EditorWindow).Assembly;
+                    System.Type type = assembly.GetType( "UnityEditor.GameView" );
+                    var gameview = EditorWindow.GetWindow(type);
+                    gameview.Repaint();
                 }
             }
         }

--- a/Editor/Editors/CinemachineStoryboardEditor.cs
+++ b/Editor/Editors/CinemachineStoryboardEditor.cs
@@ -41,11 +41,11 @@ namespace Cinemachine.Editor
                     CinemachineStoryboard.s_StoryboardGlobalMute = value;
                     Menu.SetChecked(StoryboardGlobalMuteMenuName, value);
                     
-                    //UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
-                    System.Reflection.Assembly assembly = typeof(EditorWindow).Assembly;
-                    System.Type type = assembly.GetType( "UnityEditor.GameView" );
-                    var gameview = EditorWindow.GetWindow(type);
-                    gameview.Repaint();
+                    UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
+//                    System.Reflection.Assembly assembly = typeof(EditorWindow).Assembly;
+//                    System.Type type = assembly.GetType( "UnityEditor.GameView" );
+//                    var gameview = EditorWindow.GetWindow(type);
+//                    gameview.Repaint();
                 }
             }
         }

--- a/Editor/Editors/CinemachineStoryboardEditor.cs
+++ b/Editor/Editors/CinemachineStoryboardEditor.cs
@@ -40,9 +40,8 @@ namespace Cinemachine.Editor
                     EditorPrefs.SetBool(kEnabledKey, value);
                     CinemachineStoryboard.s_StoryboardGlobalMute = value;
                     Menu.SetChecked(StoryboardGlobalMuteMenuName, value);
-#if UNITY_EDITOR
-                    UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
-#endif
+
+                    InspectorUtility.RepaintGameView();
                 }
             }
         }

--- a/Extras~/ReleaseNotes.txt
+++ b/Extras~/ReleaseNotes.txt
@@ -1,7 +1,7 @@
 <size=20><b>Version 2.5.1</b></size>
 - Bugfix (1213471, 1213434): add null check in editor
 - Bugfix (1213488): no solo for prefab vcams
-- Bugfix (1213819): RepaintAllViews on editor change
+- Bugfix (1213819): repaintGameView on editor change
 
 
 <size=20><b>Version 2.5.0</b></size>

--- a/Extras~/ReleaseNotes.txt
+++ b/Extras~/ReleaseNotes.txt
@@ -1,6 +1,7 @@
 <size=20><b>Version 2.5.1</b></size>
 - Bugfix (1213471, 1213434): add null check in editor
 - Bugfix (1213488): no solo for prefab vcams
+- Bugfix (1213819): RepaintAllViews on editor change
 
 
 <size=20><b>Version 2.5.0</b></size>

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -324,6 +324,7 @@ namespace Cinemachine
                 // Note: this call will cause any screen canvas attached to the camera
                 // to be painted one frame out of sync.  It will only happen in the editor when not playing.
                 ProcessActiveCamera(GetEffectiveDeltaTime(false));
+                UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
             }
         }
 #endif

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -324,7 +324,6 @@ namespace Cinemachine
                 // Note: this call will cause any screen canvas attached to the camera
                 // to be painted one frame out of sync.  It will only happen in the editor when not playing.
                 ProcessActiveCamera(GetEffectiveDeltaTime(false));
-                UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
             }
         }
 #endif


### PR DESCRIPTION
Addressing this ticket: https://fogbugz.unity3d.com/f/cases/1213819

I added 
```
#if UNITY_EDITOR
    UnityEditorInternal.InternalEditorUtility.RepaintAllViews();
#endif
```
where CMBrainEditor knows the editor value has changed.

**May not be a good solution**, but I could not find any problems caused by this fix, and it solved the problem.

I tested these example scenes: FollowCam, Composer and Timeline scene.

I also found an alternative solution instead of `UnityEditorInternal.InternalEditorUtility.RepaintAllViews()`, here:
https://answers.unity.com/questions/1421572/instantaneous-editorguilayoutcolorfield.html
It claims to be faster. 

Alternative solution:
```
System.Reflection.Assembly assembly = typeof(EditorWindow).Assembly;
System.Type type = assembly.GetType( "UnityEditor.GameView" );
var gameview = EditorWindow.GetWindow(type);

gameview.Repaint();
```
This code could be separated, so we don't get the gameview at every change, just once. E.g. singleton or something like that.