### PR TITLE
Bugfix (1214301, 1213836) - disallow structural change when editing v…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.5.1] - 2020-02-01
 ### Bugfixes
+- Bugfix (1214301, 1213836) - disallow structural change when editing vcam prefabs
 - Bugfix (1213471, 1213434): add null check in editor
 - Bugfix (1213488): no solo for prefab vcams
 

--- a/Editor/Editors/CinemachineVirtualCameraEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraEditor.cs
@@ -32,11 +32,13 @@ namespace Cinemachine.Editor
         bool[] m_stageError = null;
         CinemachineComponentBase[] m_components;
         UnityEditor.Editor[] m_componentEditors = new UnityEditor.Editor[0];
+        bool IsPrefab = false;
 
         protected override void OnEnable()
         {
             // Build static menu arrays via reflection
             base.OnEnable();
+            IsPrefab = Target.gameObject.scene.name == null; // causes a small GC alloc
             UpdateStaticData();
         }
 
@@ -189,6 +191,8 @@ namespace Cinemachine.Editor
 
         bool StageIsLocked(CinemachineCore.Stage stage)
         {
+            if (IsPrefab)
+                return true;
             CinemachineCore.Stage[] locked = Target.m_LockStageInInspector;
             if (locked != null)
                 for (int i = 0; i < locked.Length; ++i)
@@ -256,6 +260,8 @@ namespace Cinemachine.Editor
 
             // Get the existing components
             Transform owner = Target.GetComponentOwner();
+            if (owner == null)
+                return; // maybe it's a prefab
 
             CinemachineComponentBase[] components = owner.GetComponents<CinemachineComponentBase>();
             if (components == null)
@@ -366,7 +372,7 @@ namespace Cinemachine.Editor
             bool dirty = (numComponents == 0);
             for (int i = 0; i < numComponents; ++i)
             {
-                if (components[i] != m_components[i])
+                if (m_components[i] == null || components[i] != m_components[i])
                 {
                     dirty = true;
                     m_components[i] = components[i];

--- a/Extras~/ReleaseNotes.txt
+++ b/Extras~/ReleaseNotes.txt
@@ -1,4 +1,5 @@
 <size=20><b>Version 2.5.1</b></size>
+- Bugfix (1214301, 1213836) - disallow structural change when editing vcam prefabs
 - Bugfix (1213471, 1213434): add null check in editor
 - Bugfix (1213488): no solo for prefab vcams
 

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -197,11 +197,15 @@ namespace Cinemachine
         {
 #if UNITY_EDITOR
             bool isPrefab = gameObject.scene.name == null; // causes a small GC alloc
-            if (!isPrefab)
-#endif
+            if (isPrefab || UnityEditor.PrefabUtility.GetPrefabInstanceStatus(gameObject)
+                    != UnityEditor.PrefabInstanceStatus.NotAPrefab)
             {
-                DestroyRigs();
+                Debug.Log("You cannot reset a prefab instance.  "
+                    + "First disconnect this instance from the prefab, or enter Prefab Edit mode");
+                return;
             }
+#endif
+            DestroyRigs();
         }
 
         public override bool PreviousStateIsValid
@@ -211,7 +215,8 @@ namespace Cinemachine
             {
                 if (value == false)
                     for (int i = 0; m_Rigs != null && i < m_Rigs.Length; ++i)
-                        m_Rigs[i].PreviousStateIsValid = value;
+                        if (m_Rigs[i] != null)
+                            m_Rigs[i].PreviousStateIsValid = value;
                 base.PreviousStateIsValid = value;
             }
         }
@@ -548,7 +553,7 @@ namespace Cinemachine
                     m_Rigs = CreateRigs(copyFrom);
                 }
             }
-            for (int i = 0; m_Rigs != null && i < 3; ++i)
+            for (int i = 0; m_Rigs != null && i < 3 && i < m_Rigs.Length; ++i)
                 if (m_Rigs[i] != null)
                     CinemachineVirtualCamera.SetFlagsForHiddenChild(m_Rigs[i].gameObject);
 #endif

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -195,7 +195,13 @@ namespace Cinemachine
 
         void Reset()
         {
-            DestroyRigs();
+#if UNITY_EDITOR
+            bool isPrefab = gameObject.scene.name == null; // causes a small GC alloc
+            if (!isPrefab)
+#endif
+            {
+                DestroyRigs();
+            }
         }
 
         public override bool PreviousStateIsValid
@@ -564,6 +570,8 @@ namespace Cinemachine
             foreach (var rig in m_Rigs)
             {
                 // Configure the UI
+                if (rig == null)
+                    continue;
                 rig.m_ExcludedPropertiesInInspector = m_CommonLens
                     ? new string[] { "m_Script", "Header", "Extensions", "m_Priority", "m_Transitions", "m_Follow", "m_StandbyUpdate", "m_Lens" }
                     : new string[] { "m_Script", "Header", "Extensions", "m_Priority", "m_Transitions", "m_Follow", "m_StandbyUpdate" };

--- a/Runtime/Behaviours/CinemachineVirtualCamera.cs
+++ b/Runtime/Behaviours/CinemachineVirtualCamera.cs
@@ -197,6 +197,15 @@ namespace Cinemachine
 
         void Reset()
         {
+#if UNITY_EDITOR
+            if (UnityEditor.PrefabUtility.GetPrefabInstanceStatus(gameObject)
+                != UnityEditor.PrefabInstanceStatus.NotAPrefab)
+            {
+                Debug.Log("You cannot reset a prefab instance.  "
+                    + "First disconnect this instance from the prefab, or enter Prefab Edit mode");
+                return;
+            }
+#endif
             DestroyPipeline();
         }
 

--- a/Runtime/Behaviours/CinemachineVirtualCamera.cs
+++ b/Runtime/Behaviours/CinemachineVirtualCamera.cs
@@ -236,14 +236,20 @@ namespace Cinemachine
                 if (child.GetComponent<CinemachinePipeline>() != null)
                     oldPipeline.Add(child);
 
-            foreach (Transform child in oldPipeline)
+#if UNITY_EDITOR
+            bool isPrefab = gameObject.scene.name == null; // causes a small GC alloc
+            if (!isPrefab)
+#endif
             {
-                if (DestroyPipelineOverride != null)
-                    DestroyPipelineOverride(child.gameObject);
-                else
-                    Destroy(child.gameObject);
+                foreach (Transform child in oldPipeline)
+                {
+                    if (DestroyPipelineOverride != null)
+                        DestroyPipelineOverride(child.gameObject);
+                    else
+                        Destroy(child.gameObject);
+                }
+                m_ComponentOwner = null;
             }
-            m_ComponentOwner = null;
             PreviousStateIsValid = false;
         }
 
@@ -314,6 +320,8 @@ namespace Cinemachine
         {
             // Get the existing components
             Transform owner = GetComponentOwner();
+            if (owner == null)
+                return null; // maybe it's a prefab
             CinemachineComponentBase[] components = owner.GetComponents<CinemachineComponentBase>();
 
             T component = owner.gameObject.AddComponent<T>();


### PR DESCRIPTION
Bugfix (1214301, 1213836) - disallow structural change when editing vcam prefabs.

To modify prefab structure (new components, game objects), you must drag the prefab into the scene, edit the instance, then apply that back to the prefab.  This is standard Unity workflow, and the vcam inspectors now enforce it.

