### PR TITLE
Add Convert to TargetGroup option on LookAt and Follow target fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 
 ## [2.5.1] - 2020-02-01
-### Bugfixes
+### Mostly Bugfixes
+- Add Convert to TargetGroup option on LookAt and Follow target fields
 - Bugfix (1214301, 1213836) - disallow structural change when editing vcam prefabs
 - Bugfix (1213471, 1213434): add null check in editor
 - Bugfix (1213488): no solo for prefab vcams

--- a/Editor/PropertyDrawers/NoiseSettingsPropertyDrawer.cs
+++ b/Editor/PropertyDrawers/NoiseSettingsPropertyDrawer.cs
@@ -22,7 +22,7 @@ namespace Cinemachine.Editor
                 property.objectReferenceValue = newProfile;
                 property.serializedObject.ApplyModifiedProperties();
             }
-            rect.x += rect.width; rect.width = iconSize; rect.height = iconSize;
+            rect.x += rect.width; rect.width = iconSize; rect.height = iconSize; rect.y -= 2;
             if (GUI.Button(rect, EditorGUIUtility.IconContent("_Popup"), GUI.skin.label))
             {
                 GenericMenu menu = new GenericMenu();
@@ -106,7 +106,7 @@ namespace Cinemachine.Editor
 
         NoiseSettings CreateProfile(SerializedProperty property, string label, NoiseSettings copyFrom)
         {
-            string path = GetObjectName(property) + " " + label;
+            string path = InspectorUtility.GetVirtualCameraObjectName(property) + " " + label;
             path = EditorUtility.SaveFilePanelInProject(
                     "Create Noise Profile asset", path, "asset", 
                     "This asset will generate a procedural noise signal");
@@ -132,27 +132,6 @@ namespace Cinemachine.Editor
                 return profile;
             }
             return null;
-        }
-
-        static string GetObjectName(SerializedProperty property)
-        {
-            // A little hacky here, as we favour virtual cameras...
-            var obj = property.serializedObject.targetObject;
-            GameObject go = obj as GameObject;
-            if (go == null)
-            {
-                var component = obj as Component;
-                if (component != null)
-                    go = component.gameObject;
-            }
-            if (go != null)
-            {
-                var vcam = go.GetComponentInParent<CinemachineVirtualCameraBase>();
-                if (vcam != null)
-                    return vcam.Name;
-                return go.name;
-            }
-            return obj.name;
         }
     }
 }

--- a/Editor/PropertyDrawers/VcamTargetPropertyDrawer.cs
+++ b/Editor/PropertyDrawers/VcamTargetPropertyDrawer.cs
@@ -1,0 +1,43 @@
+using UnityEngine;
+using UnityEditor;
+using System.Collections.Generic;
+
+namespace Cinemachine.Editor
+{
+    [CustomPropertyDrawer(typeof(VcamTargetPropertyAttribute))]
+    internal sealed class VcamTargetPropertyDrawer : PropertyDrawer
+    {
+        public override void OnGUI(Rect rect, SerializedProperty property, GUIContent label)
+        {
+            const float hSpace = 2;
+            float iconSize = rect.height + 4;
+            rect.width -= iconSize + hSpace;
+            EditorGUI.PropertyField(rect, property, label);
+            rect.x += rect.width + hSpace; rect.width = iconSize;
+
+            var oldEnabled = GUI.enabled;
+            var target = property.objectReferenceValue as Transform;
+            if (target == null || target.GetComponent<CinemachineTargetGroup>() != null)
+                GUI.enabled = false;
+            if (GUI.Button(rect, EditorGUIUtility.IconContent("_Popup"), GUI.skin.label))
+            {
+                GenericMenu menu = new GenericMenu();
+                menu.AddItem(new GUIContent("Convert to TargetGroup"), false, () =>
+                {
+                    GameObject go = InspectorUtility.CreateGameObject(
+                            CinemachineMenu.GenerateUniqueObjectName(
+                                typeof(CinemachineTargetGroup), "CM TargetGroup"),
+                            typeof(CinemachineTargetGroup));
+                    var group = go.GetComponent<CinemachineTargetGroup>();
+                    Undo.RegisterCreatedObjectUndo(go, "convert to TargetGroup");
+                    group.m_RotationMode = CinemachineTargetGroup.RotationMode.GroupAverage;
+                    group.AddMember(target, 1, 1);
+                    property.objectReferenceValue = group.Transform;
+                    property.serializedObject.ApplyModifiedProperties();
+                });
+                menu.ShowAsContext();
+            }
+            GUI.enabled = oldEnabled;
+        }
+    }
+}

--- a/Editor/PropertyDrawers/VcamTargetPropertyDrawer.cs.meta
+++ b/Editor/PropertyDrawers/VcamTargetPropertyDrawer.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b0a256055e11cf4999a9ee9e8b0db2a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Utility/InspectorUtility.cs
+++ b/Editor/Utility/InspectorUtility.cs
@@ -178,5 +178,32 @@ namespace Cinemachine.Editor
 
         // Needed for 2019.3 and later, for catching GameView mouse dragging the guides
         internal static bool RepaintRequested { get; set; }
+
+        /// <summary>
+        /// Try to get the name of the owning virtual camera oibject.  If none then use
+        /// the object's name
+        /// </summary>
+        /// <param name="property"></param>
+        /// <returns></returns>
+        internal static string GetVirtualCameraObjectName(SerializedProperty property)
+        {
+            // A little hacky here, as we favour virtual cameras...
+            var obj = property.serializedObject.targetObject;
+            GameObject go = obj as GameObject;
+            if (go == null)
+            {
+                var component = obj as Component;
+                if (component != null)
+                    go = component.gameObject;
+            }
+            if (go != null)
+            {
+                var vcam = go.GetComponentInParent<CinemachineVirtualCameraBase>();
+                if (vcam != null)
+                    return vcam.Name;
+                return go.name;
+            }
+            return obj.name;
+        }
     }
 }

--- a/Extras~/ReleaseNotes.txt
+++ b/Extras~/ReleaseNotes.txt
@@ -1,4 +1,5 @@
 <size=20><b>Version 2.5.1</b></size>
+- Add Convert to TargetGroup option on LookAt and Follow target fields
 - Bugfix (1214301, 1213836) - disallow structural change when editing vcam prefabs
 - Bugfix (1213471, 1213434): add null check in editor
 - Bugfix (1213488): no solo for prefab vcams

--- a/Runtime/Behaviours/CinemachineBlendListCamera.cs
+++ b/Runtime/Behaviours/CinemachineBlendListCamera.cs
@@ -26,11 +26,13 @@ namespace Cinemachine
         /// <summary>Default object for the camera children to look at (the aim target), if not specified in a child rig.  May be empty</summary>
         [Tooltip("Default object for the camera children to look at (the aim target), if not specified in a child camera.  May be empty if all of the children define targets of their own.")]
         [NoSaveDuringPlay]
+        [VcamTargetProperty]
         public Transform m_LookAt = null;
 
         /// <summary>Default object for the camera children wants to move with (the body target), if not specified in a child rig.  May be empty</summary>
         [Tooltip("Default object for the camera children wants to move with (the body target), if not specified in a child camera.  May be empty if all of the children define targets of their own.")]
         [NoSaveDuringPlay]
+        [VcamTargetProperty]
         public Transform m_Follow = null;
 
         /// <summary>When enabled, the current camera and blend will be indicated in the game window, for debugging</summary>

--- a/Runtime/Behaviours/CinemachineClearShot.cs
+++ b/Runtime/Behaviours/CinemachineClearShot.cs
@@ -41,11 +41,13 @@ namespace Cinemachine
         /// <summary>Default object for the camera children to look at (the aim target), if not specified in a child camera.  May be empty.</summary>
         [Tooltip("Default object for the camera children to look at (the aim target), if not specified in a child camera.  May be empty if all children specify targets of their own.")]
         [NoSaveDuringPlay]
+        [VcamTargetProperty]
         public Transform m_LookAt = null;
 
         /// <summary>Default object for the camera children wants to move with (the body target), if not specified in a child camera.  May be empty.</summary>
         [Tooltip("Default object for the camera children wants to move with (the body target), if not specified in a child camera.  May be empty if all children specify targets of their own.")]
         [NoSaveDuringPlay]
+        [VcamTargetProperty]
         public Transform m_Follow = null;
 
         /// <summary>When enabled, the current camera and blend will be indicated in the game window, for debugging</summary>

--- a/Runtime/Behaviours/CinemachineExternalCamera.cs
+++ b/Runtime/Behaviours/CinemachineExternalCamera.cs
@@ -20,8 +20,10 @@ namespace Cinemachine
     public class CinemachineExternalCamera : CinemachineVirtualCameraBase
     {
         /// <summary>The object that the camera is looking at.</summary>
-        [Tooltip("The object that the camera is looking at.  Setting this will improve the quality of the blends to and from this camera")]
+        [Tooltip("The object that the camera is looking at.  Setting this will improve the "
+            + "quality of the blends to and from this camera")]
         [NoSaveDuringPlay]
+        [VcamTargetProperty]
         public Transform m_LookAt = null;
 
         private Camera m_Camera;

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -27,11 +27,13 @@ namespace Cinemachine
         /// <summary>Object for the camera children to look at (the aim target)</summary>
         [Tooltip("Object for the camera children to look at (the aim target).")]
         [NoSaveDuringPlay]
+        [VcamTargetProperty]
         public Transform m_LookAt = null;
 
         /// <summary>Object for the camera children wants to move with (the body target)</summary>
         [Tooltip("Object for the camera children wants to move with (the body target).")]
         [NoSaveDuringPlay]
+        [VcamTargetProperty]
         public Transform m_Follow = null;
 
         /// <summary>If enabled, this lens setting will apply to all three child rigs, otherwise the child rig lens settings will be used</summary>

--- a/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
+++ b/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
@@ -31,11 +31,13 @@ namespace Cinemachine
         /// <summary>Default object for the camera children to look at (the aim target), if not specified in a child rig.  May be empty</summary>
         [Tooltip("Default object for the camera children to look at (the aim target), if not specified in a child camera.  May be empty if all of the children define targets of their own.")]
         [NoSaveDuringPlay]
+        [VcamTargetProperty]
         public Transform m_LookAt = null;
 
         /// <summary>Default object for the camera children wants to move with (the body target), if not specified in a child rig.  May be empty</summary>
         [Tooltip("Default object for the camera children wants to move with (the body target), if not specified in a child camera.  May be empty if all of the children define targets of their own.")]
         [NoSaveDuringPlay]
+        [VcamTargetProperty]
         public Transform m_Follow = null;
 
         /// <summary>The state machine whose state changes will drive this camera's choice of active child</summary>

--- a/Runtime/Behaviours/CinemachineVirtualCamera.cs
+++ b/Runtime/Behaviours/CinemachineVirtualCamera.cs
@@ -69,6 +69,7 @@ namespace Cinemachine
         /// If this is null, then the vcam's Transform orientation will be used.</summary>
         [Tooltip("The object that the camera wants to look at (the Aim target).  If this is null, then the vcam's Transform orientation will define the camera's orientation.")]
         [NoSaveDuringPlay]
+        [VcamTargetProperty]
         public Transform m_LookAt = null;
 
         /// <summary>The object that the camera wants to move with (the Body target).
@@ -78,6 +79,7 @@ namespace Cinemachine
         /// If this is null, then the vcam's Transform position will be used.</summary>
         [Tooltip("The object that the camera wants to move with (the Body target).  If this is null, then the vcam's Transform position will define the camera's position.")]
         [NoSaveDuringPlay]
+        [VcamTargetProperty]
         public Transform m_Follow = null;
 
         /// <summary>Specifies the LensSettings of this Virtual Camera.

--- a/Runtime/Core/CinemachinePropertyAttribute.cs
+++ b/Runtime/Core/CinemachinePropertyAttribute.cs
@@ -16,7 +16,12 @@ namespace Cinemachine
     /// Property applied to LensSettings.  Used for custom drawing in the inspector.
     /// </summary>
     public sealed class LensSettingsPropertyAttribute : PropertyAttribute {}
-    
+
+    /// <summary>
+    /// Property applied to Vcam Target fields.  Used for custom drawing in the inspector.
+    /// </summary>
+    public sealed class VcamTargetPropertyAttribute : PropertyAttribute { }
+
     /// <summary>
     /// Property applied to CinemachineBlendDefinition.  Used for custom drawing in the inspector.
     /// </summary>

--- a/Runtime/Experimental/CinemachineNewVirtualCamera.cs
+++ b/Runtime/Experimental/CinemachineNewVirtualCamera.cs
@@ -24,11 +24,13 @@ namespace Cinemachine
         /// <summary>Object for the camera children to look at (the aim target)</summary>
         [Tooltip("Object for the camera children to look at (the aim target).")]
         [NoSaveDuringPlay]
+        [VcamTargetProperty]
         public Transform m_LookAt = null;
 
         /// <summary>Object for the camera children wants to move with (the body target)</summary>
         [Tooltip("Object for the camera children wants to move with (the body target).")]
         [NoSaveDuringPlay]
+        [VcamTargetProperty]
         public Transform m_Follow = null;
 
         /// <summary>Specifies the LensSettings of this Virtual Camera.


### PR DESCRIPTION
It shows a little gear icon next to the Follow and LookAt fields in the vcam inspector.  When the field is populated you can click on the icon to create a TragetGroup, add the object to the group, and use the group as a target.  A useful shortcut.