### PR TITLE
improvement to the 2D confining behavior of the CinemachineConfiner.

### DIFF
--- a/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/Runtime/Behaviours/CinemachineConfiner.cs
@@ -236,20 +236,28 @@ namespace Cinemachine
 
             Vector3 displacement = Vector3.zero;
             Vector3 camPos = state.CorrectedPosition;
+            Vector3 lastD = Vector3.zero;
             const int kMaxIter = 12;
             for (int i = 0; i < kMaxIter; ++i)
             {
                 Vector3 d = ConfinePoint((camPos - vy) - vx);
                 if (d.AlmostZero())
+                    d = ConfinePoint((camPos + vy) + vx);
+                if (d.AlmostZero())
                     d = ConfinePoint((camPos - vy) + vx);
                 if (d.AlmostZero())
                     d = ConfinePoint((camPos + vy) - vx);
                 if (d.AlmostZero())
-                    d = ConfinePoint((camPos + vy) + vx);
-                if (d.AlmostZero())
                     break;
+                if (d == (-1) * lastD)
+                {
+                    d *= 0.5f;
+                    displacement += d;
+                    break;
+                }
                 displacement += d;
                 camPos += d;
+                lastD = d;
             }
             return displacement;
         }


### PR DESCRIPTION
This offers a small improvement to the 2D confining behavior of the CinemachineConfiner.

This allows bounding shape to be kept in the middle of the camera regardless of whether the size of the camera is bigger than it.

Currently, if the size of the camera is bigger than the size of the bounding shape, it will loop until it reached `kMaxIter` and cause improper behavior.

`lastD` is recored for checking wether there are repetitive camera position adjustments, which suggests that the camera is larger than bounding.

`ConfinePoint((camPos + vy) + vx)` in advance is to calculate height difference, so as to avoid `displacement` cannot be adjusted vertically.