### PR TITLE
Confiner cache reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix (1213819): repaintGameView on editor change
 - Bugfix (1217306): target group position drifting when empty or when members are descendants of the group
 - Bugfix (1218695): Fully qualify UnityEditor.Menu to avoid compile errors in some circumstances
+- Bugfix: Confiner's cache is reset, when bounding shape/volume is changed.
 
 
 ## [2.5.0] - 2020-01-15

--- a/Editor/Editors/CinemachineConfinerEditor.cs
+++ b/Editor/Editors/CinemachineConfinerEditor.cs
@@ -23,9 +23,9 @@ namespace Cinemachine.Editor
                 excluded.Add(FieldPath(x => x.m_ConfineScreenEdges));
 #if CINEMACHINE_PHYSICS && CINEMACHINE_PHYSICS_2D
             if (Target.m_ConfineMode == CinemachineConfiner.Mode.Confine2D)
-                excluded.Add(FieldPath(x => x.BoundingVolume));
+                excluded.Add(FieldPath(x => x.m_BoundingVolume));
             else
-                excluded.Add(FieldPath(x => x.BoundingShape2D));
+                excluded.Add(FieldPath(x => x.m_BoundingShape2D));
 #endif
         }
 

--- a/Editor/Editors/CinemachineConfinerEditor.cs
+++ b/Editor/Editors/CinemachineConfinerEditor.cs
@@ -23,9 +23,9 @@ namespace Cinemachine.Editor
                 excluded.Add(FieldPath(x => x.m_ConfineScreenEdges));
 #if CINEMACHINE_PHYSICS && CINEMACHINE_PHYSICS_2D
             if (Target.m_ConfineMode == CinemachineConfiner.Mode.Confine2D)
-                excluded.Add(FieldPath(x => x._BoundingVolume));
+                excluded.Add(FieldPath(x => x.BoundingVolume));
             else
-                excluded.Add(FieldPath(x => x._BoundingShape2D));
+                excluded.Add(FieldPath(x => x.BoundingShape2D));
 #endif
         }
 

--- a/Editor/Editors/CinemachineConfinerEditor.cs
+++ b/Editor/Editors/CinemachineConfinerEditor.cs
@@ -23,9 +23,9 @@ namespace Cinemachine.Editor
                 excluded.Add(FieldPath(x => x.m_ConfineScreenEdges));
 #if CINEMACHINE_PHYSICS && CINEMACHINE_PHYSICS_2D
             if (Target.m_ConfineMode == CinemachineConfiner.Mode.Confine2D)
-                excluded.Add(FieldPath(x => x.m_BoundingVolume));
+                excluded.Add(FieldPath(x => x._BoundingVolume));
             else
-                excluded.Add(FieldPath(x => x.m_BoundingShape2D));
+                excluded.Add(FieldPath(x => x._BoundingShape2D));
 #endif
         }
 

--- a/Extras~/ReleaseNotes.txt
+++ b/Extras~/ReleaseNotes.txt
@@ -23,6 +23,7 @@
 - Bugfix (1213819): repaintGameView on editor change
 - Bugfix (1217306): target group position drifting when empty or when members are descendants of the group
 - Bugfix (1218695): Fully qualify UnityEditor.Menu to avoid compile errors in some circumstances
+- Bugfix: Confiner's cache is reset, when bounding shape/volume is changed.
 
 
 <size=20><b>Version 2.5.0</b></size>

--- a/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/Runtime/Behaviours/CinemachineConfiner.cs
@@ -43,7 +43,18 @@ namespace Cinemachine
 #if CINEMACHINE_PHYSICS
         /// <summary>The volume within which the camera is to be contained.</summary>
         [Tooltip("The volume within which the camera is to be contained")]
-        public Collider m_BoundingVolume;
+        [SerializeField]
+        internal Collider _BoundingVolume;
+
+        public Collider m_BoundingVolume
+        {
+            get => _BoundingVolume;
+            set
+            {
+                InvalidatePathCache();
+                _BoundingVolume = value;
+            }
+        }
 #endif
 
 #if CINEMACHINE_PHYSICS_2D
@@ -51,7 +62,7 @@ namespace Cinemachine
         /// <summary>The 2D shape within which the camera is to be contained.</summary>
         [field: Tooltip("The 2D shape within which the camera is to be contained")]
         [SerializeField]
-        private Collider2D _BoundingShape2D;
+        internal Collider2D _BoundingShape2D;
 
         public Collider2D m_BoundingShape2D
         {

--- a/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/Runtime/Behaviours/CinemachineConfiner.cs
@@ -47,9 +47,21 @@ namespace Cinemachine
 #endif
 
 #if CINEMACHINE_PHYSICS_2D
+
         /// <summary>The 2D shape within which the camera is to be contained.</summary>
-        [Tooltip("The 2D shape within which the camera is to be contained")]
-        public Collider2D m_BoundingShape2D;
+        [field: Tooltip("The 2D shape within which the camera is to be contained")]
+        [SerializeField]
+        private Collider2D _BoundingShape2D;
+
+        public Collider2D m_BoundingShape2D
+        {
+            get => _BoundingShape2D;
+            set
+            {
+                InvalidatePathCache();
+                _BoundingShape2D = value;
+            }
+        }
 #endif
         /// <summary>If camera is orthographic, screen edges will be confined to the volume.</summary>
         [Tooltip("If camera is orthographic, screen edges will be confined to the volume.  "
@@ -74,6 +86,7 @@ namespace Cinemachine
         private void OnValidate()
         {
             m_Damping = Mathf.Max(0, m_Damping);
+            m_BoundingShape2D = _BoundingShape2D;
         }
 
         class VcamExtraState

--- a/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/Runtime/Behaviours/CinemachineConfiner.cs
@@ -76,7 +76,6 @@ namespace Cinemachine
         private void OnValidate()
         {
             m_Damping = Mathf.Max(0, m_Damping);
-            InvalidatePathCache();
         }
 
         class VcamExtraState
@@ -135,15 +134,19 @@ namespace Cinemachine
         private int m_pathTotalPointCount;
 
         /// <summary>Call this if the bounding shape's points change at runtime</summary>
-        public void InvalidatePathCache() { m_pathCache = null; }
+        public void InvalidatePathCache()
+        {
+            m_pathCache = null;
+            m_BoundingShape2DCache = null;
+        }
 
         bool ValidatePathCache()
         {
 #if CINEMACHINE_PHYSICS_2D
             if (m_BoundingShape2DCache != m_BoundingShape2D)
             {
-                m_BoundingShape2DCache = m_BoundingShape2D;
                 InvalidatePathCache();
+                m_BoundingShape2DCache = m_BoundingShape2D;
             }
             
             Type colliderType = m_BoundingShape2D == null ? null:  m_BoundingShape2D.GetType();

--- a/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/Runtime/Behaviours/CinemachineConfiner.cs
@@ -60,7 +60,7 @@ namespace Cinemachine
 #if CINEMACHINE_PHYSICS_2D
 
         /// <summary>The 2D shape within which the camera is to be contained.</summary>
-        [field: Tooltip("The 2D shape within which the camera is to be contained")]
+        [Tooltip("The 2D shape within which the camera is to be contained")]
         [SerializeField]
         internal Collider2D _BoundingShape2D;
 

--- a/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/Runtime/Behaviours/CinemachineConfiner.cs
@@ -44,15 +44,15 @@ namespace Cinemachine
         /// <summary>The volume within which the camera is to be contained.</summary>
         [Tooltip("The volume within which the camera is to be contained")]
         [SerializeField]
-        internal Collider _BoundingVolume;
+        internal Collider BoundingVolume;
 
         public Collider m_BoundingVolume
         {
-            get => _BoundingVolume;
+            get => BoundingVolume;
             set
             {
                 InvalidatePathCache();
-                _BoundingVolume = value;
+                BoundingVolume = value;
             }
         }
 #endif
@@ -62,15 +62,15 @@ namespace Cinemachine
         /// <summary>The 2D shape within which the camera is to be contained.</summary>
         [Tooltip("The 2D shape within which the camera is to be contained")]
         [SerializeField]
-        internal Collider2D _BoundingShape2D;
+        internal Collider2D BoundingShape2D;
 
         public Collider2D m_BoundingShape2D
         {
-            get => _BoundingShape2D;
+            get => BoundingShape2D;
             set
             {
                 InvalidatePathCache();
-                _BoundingShape2D = value;
+                BoundingShape2D = value;
             }
         }
 #endif
@@ -97,7 +97,7 @@ namespace Cinemachine
         private void OnValidate()
         {
             m_Damping = Mathf.Max(0, m_Damping);
-            m_BoundingShape2D = _BoundingShape2D;
+            InvalidatePathCache();
         }
 
         class VcamExtraState

--- a/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/Runtime/Behaviours/CinemachineConfiner.cs
@@ -139,13 +139,13 @@ namespace Cinemachine
 
         bool ValidatePathCache()
         {
+#if CINEMACHINE_PHYSICS_2D
             if (m_BoundingShape2DCache != m_BoundingShape2D)
             {
                 m_BoundingShape2DCache = m_BoundingShape2D;
                 InvalidatePathCache();
             }
             
-#if CINEMACHINE_PHYSICS_2D
             Type colliderType = m_BoundingShape2D == null ? null:  m_BoundingShape2D.GetType();
             if (colliderType == typeof(PolygonCollider2D))
             {

--- a/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/Runtime/Behaviours/CinemachineConfiner.cs
@@ -44,7 +44,6 @@ namespace Cinemachine
         /// <summary>The volume within which the camera is to be contained.</summary>
         [Tooltip("The volume within which the camera is to be contained")]
         public Collider m_BoundingVolume;
-        private Collider m_BoundingVolumeCache;
 #endif
 
 #if CINEMACHINE_PHYSICS_2D
@@ -140,12 +139,9 @@ namespace Cinemachine
 
         bool ValidatePathCache()
         {
-            if (m_BoundingVolumeCache != m_BoundingVolume)
-            {
-                InvalidatePathCache();
-            }
             if (m_BoundingShape2DCache != m_BoundingShape2D)
             {
+                m_BoundingShape2DCache = m_BoundingShape2D;
                 InvalidatePathCache();
             }
             


### PR DESCRIPTION
When BoundingShape2D/BoundingVolume is changed, we need to invalidate the cache.

I created a getter/setter for these parameters. When they are set, the cache is invalidated.

However, when the property is changed in the editor, it is not changed through the setter, so we need to invalidate cache in the OnValidate method.


QUESTION:
Do we want to expose `InvalidatePathCache` function after this change?
```
/// <summary>Call this if the bounding shape's points change at runtime</summary>
public void InvalidatePathCache() { m_pathCache = null; }
```