### PR TITLE
Added Lookahead Reset When Still option, to reproduce legacy lookahea…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [2.6.0-preview.3] - 2020-03-28
 ### New Features and Bugfixes
+- Added Lookahead Reset When Still option, to reproduce legacy lookahead behaviour if desired
 - Added ManualUpdate mode to the Brain, to allow for custom game loop logic
 - VolumeSettings/PostProcessing: added ability to choose custom target for focus tracking
 - Added CinemachineRecomposer for timeline-tweaking of procedural or recorded vcam Aim output
@@ -17,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added example scenes: 3rdPersonDeadCenterAim and 3rdPersonLooseAim to show different 3rd person cmera styles
 - FramingTransposer does its work after Aim, so it plays better with Aim components.
 - Framing Transposer: add Damped Rotations option.  If unchecked, changes to the vcam's rotation will bypass Damping, and only target motion will be damped.
+- Added Lookahead Reset When Still option, to reproduce legacy lookahead behaviour if desired
 - Orbital Transposer / FreeLook: improved damping when target is moving
 - CustomBlends editor UX improvements: allow direct editing of vcam names, as well as dropdown
 - Add Convert to TargetGroup option on LookAt and Follow target fields

--- a/Extras~/ReleaseNotes.txt
+++ b/Extras~/ReleaseNotes.txt
@@ -9,6 +9,7 @@
 - Added example scenes: 3rdPersonDeadCenterAim and 3rdPersonLooseAim to show different 3rd person cmera styles
 - FramingTransposer does its work after Aim, so it plays better with Aim components.
 - Framing Transposer: add Damped Rotations option.  If unchecked, changes to the vcam's rotation will bypass Damping, and only target motion will be damped.
+- Added Lookahead Reset When Still option, to reproduce legacy lookahead behaviour if desired
 - Orbital Transposer / FreeLook: improved damping when target is moving
 - CustomBlends editor UX improvements: allow direct editing of vcam names, as well as dropdown
 - Add Convert to TargetGroup option on LookAt and Follow target fields

--- a/Runtime/Components/CinemachineComposer.cs
+++ b/Runtime/Components/CinemachineComposer.cs
@@ -46,6 +46,10 @@ namespace Cinemachine
         [Tooltip("If checked, movement along the Y axis will be ignored for lookahead calculations")]
         public bool m_LookaheadIgnoreY;
 
+        /// <summary>If checked, lookahead will reset when target stops moving</summary>
+        [Tooltip("If checked, lookahead will reset when target stops moving")]
+        public bool m_LookaheadResetWhenStill;
+
         /// <summary>How aggressively the camera tries to follow the target in the screen-horizontal direction.
         /// Small numbers are more responsive, rapidly orienting the camera to keep the target in
         /// the dead zone. Larger numbers give a more heavy slowly responding camera.
@@ -136,6 +140,7 @@ namespace Cinemachine
             else
             {
                 m_Predictor.Smoothing = m_LookaheadSmoothing;
+                m_Predictor.Recenter = m_LookaheadResetWhenStill;
                 m_Predictor.AddPosition(pos, VirtualCamera.PreviousStateIsValid ? deltaTime : -1, m_LookaheadTime);
                 var delta = m_Predictor.PredictPositionDelta(m_LookaheadTime);
                 if (m_LookaheadIgnoreY)

--- a/Runtime/Components/CinemachineFramingTransposer.cs
+++ b/Runtime/Components/CinemachineFramingTransposer.cs
@@ -58,6 +58,10 @@ namespace Cinemachine
         [Tooltip("If checked, movement along the Y axis will be ignored for lookahead calculations")]
         public bool m_LookaheadIgnoreY;
 
+        /// <summary>If checked, lookahead will reset when target stops moving</summary>
+        [Tooltip("If checked, lookahead will reset when target stops moving")]
+        public bool m_LookaheadResetWhenStill;
+
         /// <summary>How aggressively the camera tries to maintain the offset in the X-axis.
         /// Small numbers are more responsive, rapidly translating the camera to keep the target's
         /// x-axis offset.  Larger numbers give a more heavy slowly responding camera.
@@ -432,6 +436,7 @@ namespace Cinemachine
             if (m_LookaheadTime > Epsilon)
             {
                 m_Predictor.Smoothing = m_LookaheadSmoothing;
+                m_Predictor.Recenter = m_LookaheadResetWhenStill;
                 m_Predictor.AddPosition(followTargetPosition, deltaTime, m_LookaheadTime);
                 var delta = m_Predictor.PredictPositionDelta(m_LookaheadTime);
                 if (m_LookaheadIgnoreY)

--- a/Runtime/Core/Predictor.cs
+++ b/Runtime/Core/Predictor.cs
@@ -30,6 +30,8 @@ namespace Cinemachine.Utility
         }
         public bool IsEmpty { get { return m_Velocity.IsEmpty(); } }
 
+        public bool Recenter { get; set; }
+
         public void ApplyTransformDelta(Vector3 positionDelta)
         {
             m_Position += positionDelta;
@@ -50,12 +52,12 @@ namespace Cinemachine.Utility
             else
             {
                 Vector3 vel = (pos - m_Position) / deltaTime;
-                if (vel.sqrMagnitude > UnityVectorExtensions.Epsilon)
+                if (Recenter || vel.sqrMagnitude > UnityVectorExtensions.Epsilon)
                 {
                     Vector3 vel0 = m_Velocity.Value();
                     float now = Time.time;
                     if (vel.sqrMagnitude >= vel0.sqrMagnitude
-                        || Vector3.Angle(vel, vel0) > 10
+                        || UnityVectorExtensions.Angle(vel, vel0) > 10
                         || now > mLastVelAddedTime + lookaheadTime)
                     {
                         m_Velocity.AddValue(vel);


### PR DESCRIPTION
…d behaviour if desired
See https://forum.unity.com/threads/framing-transposer-look-ahead-stops-when-target-stops-does-not-recenter-until-target-moves-again.743615/