### PR TITLE
Dev/new lookahead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Added example scenes: 3rdPersonDeadCenterAim and 3rdPersonLooseAim to show different 3rd person cmera styles
 - FramingTransposer does its work after Aim, so it plays better with Aim components.
 - Framing Transposer: add Damped Rotations option.  If unchecked, changes to the vcam's rotation will bypass Damping, and only target motion will be damped.
-- Added Lookahead Reset When Still option, to reproduce legacy lookahead behaviour if desired
+- Refactored Lookahead - better stability.  New behaviour may require some parameter adjustment in existing content
+- Composer and Framing Transposer: improved handling at edge of hard zone (no juddering)
 - Orbital Transposer / FreeLook: improved damping when target is moving
 - CustomBlends editor UX improvements: allow direct editing of vcam names, as well as dropdown
 - Add Convert to TargetGroup option on LookAt and Follow target fields

--- a/Extras~/ReleaseNotes.txt
+++ b/Extras~/ReleaseNotes.txt
@@ -10,7 +10,8 @@
 - Added example scenes: 3rdPersonDeadCenterAim and 3rdPersonLooseAim to show different 3rd person cmera styles
 - FramingTransposer does its work after Aim, so it plays better with Aim components.
 - Framing Transposer: add Damped Rotations option.  If unchecked, changes to the vcam's rotation will bypass Damping, and only target motion will be damped.
-- Added Lookahead Reset When Still option, to reproduce legacy lookahead behaviour if desired
+- Refactored Lookahead - new behaviour may require some parameter adjustment in existing content
+- Composer and Framing Transposer: improved handling at edge of hard zone (no juddering)
 - Orbital Transposer / FreeLook: improved damping when target is moving
 - CustomBlends editor UX improvements: allow direct editing of vcam names, as well as dropdown
 - Add Convert to TargetGroup option on LookAt and Follow target fields

--- a/Extras~/ReleaseNotes.txt
+++ b/Extras~/ReleaseNotes.txt
@@ -10,7 +10,7 @@
 - Added example scenes: 3rdPersonDeadCenterAim and 3rdPersonLooseAim to show different 3rd person cmera styles
 - FramingTransposer does its work after Aim, so it plays better with Aim components.
 - Framing Transposer: add Damped Rotations option.  If unchecked, changes to the vcam's rotation will bypass Damping, and only target motion will be damped.
-- Refactored Lookahead - new behaviour may require some parameter adjustment in existing content
+- Refactored Lookahead - better stability.  New behaviour may require some parameter adjustment in existing content
 - Composer and Framing Transposer: improved handling at edge of hard zone (no juddering)
 - Orbital Transposer / FreeLook: improved damping when target is moving
 - CustomBlends editor UX improvements: allow direct editing of vcam names, as well as dropdown

--- a/Runtime/Components/CinemachineComposer.cs
+++ b/Runtime/Components/CinemachineComposer.cs
@@ -46,10 +46,6 @@ namespace Cinemachine
         [Tooltip("If checked, movement along the Y axis will be ignored for lookahead calculations")]
         public bool m_LookaheadIgnoreY;
 
-        /// <summary>If checked, lookahead will reset when target stops moving</summary>
-        [Tooltip("If checked, lookahead will reset when target stops moving")]
-        public bool m_LookaheadResetWhenStill;
-
         /// <summary>How aggressively the camera tries to follow the target in the screen-horizontal direction.
         /// Small numbers are more responsive, rapidly orienting the camera to keep the target in
         /// the dead zone. Larger numbers give a more heavy slowly responding camera.
@@ -140,7 +136,6 @@ namespace Cinemachine
             else
             {
                 m_Predictor.Smoothing = m_LookaheadSmoothing;
-                m_Predictor.Recenter = m_LookaheadResetWhenStill;
                 m_Predictor.AddPosition(pos, VirtualCamera.PreviousStateIsValid ? deltaTime : -1, m_LookaheadTime);
                 var delta = m_Predictor.PredictPositionDelta(m_LookaheadTime);
                 if (m_LookaheadIgnoreY)

--- a/Runtime/Components/CinemachineComposer.cs
+++ b/Runtime/Components/CinemachineComposer.cs
@@ -39,8 +39,8 @@ namespace Cinemachine
         /// <summary>Controls the smoothness of the lookahead algorithm.  Larger values smooth out
         /// jittery predictions and also increase prediction lag</summary>
         [Tooltip("Controls the smoothness of the lookahead algorithm.  Larger values smooth out jittery predictions and also increase prediction lag")]
-        [Range(3, 30)]
-        public float m_LookaheadSmoothing = 10;
+        [Range(0, 30)]
+        public float m_LookaheadSmoothing = 0;
 
         /// <summary>If checked, movement along the Y axis will be ignored for lookahead calculations</summary>
         [Tooltip("If checked, movement along the Y axis will be ignored for lookahead calculations")]
@@ -255,25 +255,16 @@ namespace Cinemachine
                         -m_ScreenOffsetPrevFrame, curState.ReferenceUp);
                 }
 
-                // First force the previous rotation into the hard bounds, no damping,
-                // then  move it through the soft zone, with damping
-                if (deltaTime < 0 || VirtualCamera.LookAtTargetAttachment > 1 - Epsilon)
-                {
-                    RotateToScreenBounds(
-                        ref curState, mCache.mFovHardGuideRect, TrackedPoint,
-                        ref rigOrientation, mCache.mFov, mCache.mFovH, -1);
-                }
+                // Move target through the soft zone, with damping
                 RotateToScreenBounds(
                     ref curState, mCache.mFovSoftGuideRect, TrackedPoint,
                     ref rigOrientation, mCache.mFov, mCache.mFovH, deltaTime);
-            }
 
-            // If we have lookahead, make sure the real target is still in the frame
-            if (!(TrackedPoint - curState.ReferenceLookAt).AlmostZero())
-            {
-                RotateToScreenBounds(
-                    ref curState, mCache.mFovHardGuideRect, curState.ReferenceLookAt,
-                    ref rigOrientation, mCache.mFov, mCache.mFovH, -1);
+                // Force the actual target (not the lookahead one) into the hard bounds, no damping
+                if (deltaTime < 0 || VirtualCamera.LookAtTargetAttachment > 1 - Epsilon)
+                    RotateToScreenBounds(
+                        ref curState, mCache.mFovHardGuideRect, curState.ReferenceLookAt,
+                        ref rigOrientation, mCache.mFov, mCache.mFovH, -1);
             }
 
             m_CameraPosPrevFrame = curState.CorrectedPosition;

--- a/Runtime/Components/CinemachineFramingTransposer.cs
+++ b/Runtime/Components/CinemachineFramingTransposer.cs
@@ -536,7 +536,8 @@ namespace Cinemachine
                     cameraOffset, new Vector3(m_XDamping, m_YDamping, m_ZDamping), deltaTime);
 
                 // Make sure the real target (not the lookahead one) is still in the frame
-                if (!m_UnlimitedSoftZone)
+                if (!m_UnlimitedSoftZone 
+                    && (deltaTime < 0 || VirtualCamera.FollowTargetAttachment > 1 - Epsilon))
                 {
                     Rect hardGuideOrtho = ScreenToOrtho(HardGuideRect, screenSize, lens.Aspect);
                     var realTargetPos = (worldToLocal * followTargetPosition) - cameraPos;

--- a/Runtime/Components/CinemachineFramingTransposer.cs
+++ b/Runtime/Components/CinemachineFramingTransposer.cs
@@ -58,10 +58,6 @@ namespace Cinemachine
         [Tooltip("If checked, movement along the Y axis will be ignored for lookahead calculations")]
         public bool m_LookaheadIgnoreY;
 
-        /// <summary>If checked, lookahead will reset when target stops moving</summary>
-        [Tooltip("If checked, lookahead will reset when target stops moving")]
-        public bool m_LookaheadResetWhenStill;
-
         /// <summary>How aggressively the camera tries to maintain the offset in the X-axis.
         /// Small numbers are more responsive, rapidly translating the camera to keep the target's
         /// x-axis offset.  Larger numbers give a more heavy slowly responding camera.
@@ -447,7 +443,6 @@ namespace Cinemachine
             if (m_LookaheadTime > Epsilon)
             {
                 m_Predictor.Smoothing = m_LookaheadSmoothing;
-                m_Predictor.Recenter = m_LookaheadResetWhenStill;
                 m_Predictor.AddPosition(followTargetPosition, deltaTime, m_LookaheadTime);
                 var delta = m_Predictor.PredictPositionDelta(m_LookaheadTime);
                 if (m_LookaheadIgnoreY)

--- a/Runtime/Components/CinemachineFramingTransposer.cs
+++ b/Runtime/Components/CinemachineFramingTransposer.cs
@@ -51,8 +51,8 @@ namespace Cinemachine
         /// jittery predictions and also increase prediction lag</summary>
         [Tooltip("Controls the smoothness of the lookahead algorithm.  Larger values smooth out "
             + "jittery predictions and also increase prediction lag")]
-        [Range(3, 30)]
-        public float m_LookaheadSmoothing = 10;
+        [Range(0, 30)]
+        public float m_LookaheadSmoothing = 0;
 
         /// <summary>If checked, movement along the Y axis will be ignored for lookahead calculations</summary>
         [Tooltip("If checked, movement along the Y axis will be ignored for lookahead calculations")]
@@ -535,29 +535,18 @@ namespace Cinemachine
             }
             else
             {
-                // Move it through the soft zone
+                // Move it through the soft zone, with damping
                 cameraOffset += OrthoOffsetToScreenBounds(targetPos, softGuideOrtho);
+                cameraOffset = VirtualCamera.DetachedFollowTargetDamp(
+                    cameraOffset, new Vector3(m_XDamping, m_YDamping, m_ZDamping), deltaTime);
 
-                // Find where it intersects the hard zone
-                Vector3 hard = Vector3.zero;
-                if (!m_UnlimitedSoftZone && deltaTime < 0 
-                    || VirtualCamera.FollowTargetAttachment > 1 - Epsilon)
+                // Make sure the real target (not the lookahead one) is still in the frame
+                if (!m_UnlimitedSoftZone)
                 {
                     Rect hardGuideOrtho = ScreenToOrtho(HardGuideRect, screenSize, lens.Aspect);
-                    hard = OrthoOffsetToScreenBounds(targetPos, hardGuideOrtho);
-                    float t = Mathf.Max(
-                        hard.x / (cameraOffset.x + Epsilon), hard.y / (cameraOffset.y + Epsilon));
-                    hard = cameraOffset * t;
-                }
-                // Apply damping, but only to the portion of the move that's inside the hard zone
-                cameraOffset = hard + VirtualCamera.DetachedFollowTargetDamp(
-                    cameraOffset - hard, new Vector3(m_XDamping, m_YDamping, m_ZDamping), deltaTime);
-
-                // If we have lookahead, make sure the real target is still in the frame
-                if (!m_UnlimitedSoftZone && !(TrackedPoint - curState.ReferenceLookAt).AlmostZero())
-                {
-                    Rect hardGuideOrtho = ScreenToOrtho(HardGuideRect, screenSize, lens.Aspect);
-                    cameraOffset += OrthoOffsetToScreenBounds(lookAtPos - cameraOffset, hardGuideOrtho);
+                    var realTargetPos = (worldToLocal * followTargetPosition) - cameraPos;
+                    cameraOffset += OrthoOffsetToScreenBounds(
+                        realTargetPos - cameraOffset, hardGuideOrtho);
                 }
             }
             curState.RawPosition = localToWorld * (cameraPos + cameraOffset);


### PR DESCRIPTION
This is the DOTS version of Lookahead ported back to Classic.  It's much more stable and a massively simpler implementation.  Also included is improved jitter-free handling of composer/FramingTransposer hard zones when the target is right on the edge.

The new lookahead behaviour needs to be verified for acceptability by Adam, after the PR is approved.