### PR TITLE
Dev/2dconfinerscalebug 1234966

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix (1227606): Timeline preview and playmode not the same for composer with hand-animated rotations
 - Bugfix: Confiner's cache is reset, when bounding shape/volume is changed.
 - Bugfix (1232146): Vcam no longer jerks at edge of confiner bound box.
+- Bugfix (1234966): CompositeCollider scale was applied twice.
 
 
 ## [2.5.0] - 2020-01-15

--- a/Editor/Editors/CinemachineConfinerEditor.cs
+++ b/Editor/Editors/CinemachineConfinerEditor.cs
@@ -141,7 +141,7 @@ namespace Cinemachine.Editor
 #endif
 #if CINEMACHINE_PHYSICS_2D
                     Transform t = confiner.m_BoundingShape2D.transform;
-                    Gizmos.matrix = Matrix4x4.TRS(t.position, t.rotation, t.lossyScale);
+                    Gizmos.matrix = Matrix4x4.TRS(t.position, t.rotation, Vector3.one);
 
                     Type colliderType = confiner.m_BoundingShape2D.GetType();
                     if (colliderType == typeof(PolygonCollider2D))

--- a/Editor/Editors/CinemachineConfinerEditor.cs
+++ b/Editor/Editors/CinemachineConfinerEditor.cs
@@ -154,13 +154,13 @@ namespace Cinemachine.Editor
                     {
                         CompositeCollider2D poly = confiner.m_BoundingShape2D as CompositeCollider2D;
                         Vector2[] path = new Vector2[poly.pointCount];
-                        Vector2 scaleBack = new Vector2(1f / t.lossyScale.x, 1f / t.lossyScale.y);
+                        Vector2 revertCompositeColliderScale = new Vector2(1f / t.lossyScale.x, 1f / t.lossyScale.y);
                         for (int i = 0; i < poly.pathCount; ++i)
                         {
                             int numPoints = poly.GetPath(i, path);
                             for (int j = 0; j < path.Length; ++j)
                             {
-                                path[j] *= scaleBack;
+                                path[j] *= revertCompositeColliderScale;
                             }
                             DrawPath(path, numPoints);
                         }

--- a/Editor/Editors/CinemachineConfinerEditor.cs
+++ b/Editor/Editors/CinemachineConfinerEditor.cs
@@ -141,7 +141,7 @@ namespace Cinemachine.Editor
 #endif
 #if CINEMACHINE_PHYSICS_2D
                     Transform t = confiner.m_BoundingShape2D.transform;
-                    Gizmos.matrix = Matrix4x4.TRS(t.position, t.rotation, Vector3.one);
+                    Gizmos.matrix = Matrix4x4.TRS(t.position, t.rotation, t.lossyScale);
 
                     Type colliderType = confiner.m_BoundingShape2D.GetType();
                     if (colliderType == typeof(PolygonCollider2D))
@@ -154,9 +154,14 @@ namespace Cinemachine.Editor
                     {
                         CompositeCollider2D poly = confiner.m_BoundingShape2D as CompositeCollider2D;
                         Vector2[] path = new Vector2[poly.pointCount];
+                        Vector2 scaleBack = new Vector2(1f / t.lossyScale.x, 1f / t.lossyScale.y);
                         for (int i = 0; i < poly.pathCount; ++i)
                         {
                             int numPoints = poly.GetPath(i, path);
+                            for (int j = 0; j < path.Length; ++j)
+                            {
+                                path[j] *= scaleBack;
+                            }
                             DrawPath(path, numPoints);
                         }
                     }

--- a/Extras~/ReleaseNotes.txt
+++ b/Extras~/ReleaseNotes.txt
@@ -33,6 +33,7 @@
 - Bugfix (1227606): Timeline preview and playmode not the same for composer with hand-animated rotations
 - Bugfix: Confiner's cache is reset, when bounding shape/volume is changed.
 - Bugfix (1232146): Vcam no longer jerks at edge of confiner bound box.
+- Bugfix (1234966): CompositeCollider scale was applied twice.
 
 
 <size=20><b>Version 2.5.0</b></size>

--- a/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/Runtime/Behaviours/CinemachineConfiner.cs
@@ -197,12 +197,16 @@ namespace Cinemachine
                 {
                     m_pathCache = new List<List<Vector2>>();
                     Vector2[] path = new Vector2[poly.pointCount];
+                    var lossyScale = m_BoundingShape2D.transform.lossyScale;
+                    Vector2 compositeScale = new Vector2(
+                        1f / lossyScale.x, 
+                        1f / lossyScale.y);
                     for (int i = 0; i < poly.pathCount; ++i)
                     {
                         int numPoints = poly.GetPath(i, path);
                         List<Vector2> dst = new List<Vector2>();
                         for (int j = 0; j < numPoints; ++j)
-                            dst.Add(path[j]);
+                            dst.Add(compositeScale * path[j]);
                         m_pathCache.Add(dst);
                     }
                     m_pathTotalPointCount = poly.pointCount;
@@ -240,12 +244,10 @@ namespace Cinemachine
                 int numPoints = m_pathCache[i].Count;
                 if (numPoints > 0)
                 {
-                    Transform t = m_BoundingShape2D.transform;
-                    var localToWorldWithoutScale = Matrix4x4.TRS(t.position, t.rotation, Vector3.one);
-                    Vector2 v0 = localToWorldWithoutScale * m_pathCache[i][numPoints-1];
+                    Vector2 v0 = m_BoundingShape2D.transform.TransformPoint(m_pathCache[i][numPoints - 1]);
                     for (int j = 0; j < numPoints; ++j)
                     {
-                        Vector2 v = localToWorldWithoutScale * m_pathCache[i][j];
+                        Vector2 v = m_BoundingShape2D.transform.TransformPoint(m_pathCache[i][j]);
                         Vector2 c = Vector2.Lerp(v0, v, p.ClosestPointOnSegment(v0, v));
                         float d = Vector2.SqrMagnitude(p - c);
                         if (d < bestDistance)

--- a/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/Runtime/Behaviours/CinemachineConfiner.cs
@@ -198,7 +198,7 @@ namespace Cinemachine
                     m_pathCache = new List<List<Vector2>>();
                     Vector2[] path = new Vector2[poly.pointCount];
                     var lossyScale = m_BoundingShape2D.transform.lossyScale;
-                    Vector2 compositeScale = new Vector2(
+                    Vector2 revertCompositeColliderScale = new Vector2(
                         1f / lossyScale.x, 
                         1f / lossyScale.y);
                     for (int i = 0; i < poly.pathCount; ++i)
@@ -206,7 +206,7 @@ namespace Cinemachine
                         int numPoints = poly.GetPath(i, path);
                         List<Vector2> dst = new List<Vector2>();
                         for (int j = 0; j < numPoints; ++j)
-                            dst.Add(compositeScale * path[j]);
+                            dst.Add(revertCompositeColliderScale * path[j]);
                         m_pathCache.Add(dst);
                     }
                     m_pathTotalPointCount = poly.pointCount;

--- a/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/Runtime/Behaviours/CinemachineConfiner.cs
@@ -240,10 +240,12 @@ namespace Cinemachine
                 int numPoints = m_pathCache[i].Count;
                 if (numPoints > 0)
                 {
-                    Vector2 v0 = m_BoundingShape2D.transform.TransformPoint(m_pathCache[i][numPoints-1]);
+                    Transform t = m_BoundingShape2D.transform;
+                    var localToWorldWithoutScale = Matrix4x4.TRS(t.position, t.rotation, Vector3.one);
+                    Vector2 v0 = localToWorldWithoutScale * m_pathCache[i][numPoints-1];
                     for (int j = 0; j < numPoints; ++j)
                     {
-                        Vector2 v = m_BoundingShape2D.transform.TransformPoint(m_pathCache[i][j]);
+                        Vector2 v = localToWorldWithoutScale * m_pathCache[i][j];
                         Vector2 c = Vector2.Lerp(v0, v, p.ClosestPointOnSegment(v0, v));
                         float d = Vector2.SqrMagnitude(p - c);
                         if (d < bestDistance)

--- a/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/Runtime/Behaviours/CinemachineConfiner.cs
@@ -206,7 +206,7 @@ namespace Cinemachine
                         int numPoints = poly.GetPath(i, path);
                         List<Vector2> dst = new List<Vector2>();
                         for (int j = 0; j < numPoints; ++j)
-                            dst.Add(revertCompositeColliderScale * path[j]);
+                            dst.Add(path[j] * revertCompositeColliderScale);
                         m_pathCache.Add(dst);
                     }
                     m_pathTotalPointCount = poly.pointCount;


### PR DESCRIPTION
Fixes https://fogbugz.unity3d.com/f/cases/resolve/1234966/.

The bug was that when using Composite collider, the points we saved in m_pathCache were already scaled by the global scale, because Composite Collider returns its path already scaled.

Whereas, when using Polygon Collider (2D), or 3D colliders, this is not the case.

To me, this is not intuitive. I don't know why they implemented composite collider this way. They don't mention this in the docs either. I asked the Physics people on the forum - have not received an answer yet.

---------------------------------------

So to fix this, I revert the scale when saving to m_pathCache in the case of Composite Collider by multiplying the points by 1/scale.

The problem was in `private Vector3 ConfinePoint(Vector3 camPos)`:
```
// ...
Vector2 v0 = m_BoundingShape2D.transform.TransformPoint(m_pathCache[i][numPoints - 1]);
for (int j = 0; j < numPoints; ++j)
{
     Vector2 v = m_BoundingShape2D.transform.TransformPoint(m_pathCache[i][j]);
     // ...
```

Same happened in GizmoDrawing.

Because here we applied the scale the second time. First was automatically done by Composite Collider.
