### PR TITLE
Dev/new input system

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -17,3 +17,4 @@ upm-ci~/**
 *.zip*
 TestRunnerOptions.json
 .idea/**
+upm-ci.log

--- a/Editor/Editors/CinemachineFreeLookEditor.cs
+++ b/Editor/Editors/CinemachineFreeLookEditor.cs
@@ -23,6 +23,12 @@ namespace Cinemachine
             }
         }
 
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            Target.UpdateInputAxisProvider();
+        }
+        
         protected override void OnDisable()
         {
             base.OnDisable();

--- a/Editor/Editors/CinemachineOrbitalTransposerEditor.cs
+++ b/Editor/Editors/CinemachineOrbitalTransposerEditor.cs
@@ -66,6 +66,11 @@ namespace Cinemachine.Editor
             }
         }
 
+        private void OnEnable()
+        {
+            Target.UpdateInputAxisProvider();
+        }
+
         public override void OnInspectorGUI()
         {
             BeginInspector();

--- a/Editor/Editors/CinemachinePOVEditor.cs
+++ b/Editor/Editors/CinemachinePOVEditor.cs
@@ -5,5 +5,9 @@ namespace Cinemachine.Editor
     [CustomEditor(typeof(CinemachinePOV))]
     internal sealed class CinemachinePOVEditor : BaseEditor<CinemachinePOV>
     {
+        private void OnEnable()
+        {
+            Target.UpdateInputAxisProvider();
+        }
     }
 }

--- a/Editor/Experimental/CinemachineNewFreeLookEditor.cs
+++ b/Editor/Experimental/CinemachineNewFreeLookEditor.cs
@@ -34,6 +34,7 @@ namespace Cinemachine
         {
             base.OnEnable();
             mPipelineSet.CreateSubeditors(this);
+            Target.UpdateInputAxisProvider();
         }
 
         protected override void OnDisable()

--- a/Editor/PropertyDrawers/AxisStatePropertyDrawer.cs
+++ b/Editor/PropertyDrawers/AxisStatePropertyDrawer.cs
@@ -62,8 +62,12 @@ namespace Cinemachine.Editor
                                 new GUIContent("Time")} );
                 }
 
-                rect.y += height + vSpace;
-                EditorGUI.PropertyField(rect, property.FindPropertyRelative(() => def.m_InputAxisName));
+                if (!HasInputProvider(property))
+                {
+                    rect.y += height + vSpace;
+                    EditorGUI.PropertyField(
+                        rect, property.FindPropertyRelative(() => def.m_InputAxisName));
+                }
 
                 rect.y += height + vSpace;
                 InspectorUtility.MultiPropertyOnLine(rect, null,
@@ -80,8 +84,10 @@ namespace Cinemachine.Editor
             float height = EditorGUIUtility.singleLineHeight + vSpace;
             if (mExpanded)
             {
-                int lines = 6;
+                int lines = 5;
                 if (!ValueRangeIsLocked(property))
+                    ++lines;
+                if (!HasInputProvider(property))
                     ++lines;
                 if (HasRecentering(property))
                     ++lines;
@@ -105,6 +111,16 @@ namespace Cinemachine.Editor
             bool value = false;
             PropertyInfo pi = typeof(AxisState).GetProperty(
                 "HasRecentering", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+            if (pi != null)
+                value = bool.Equals(true, pi.GetValue(SerializedPropertyHelper.GetPropertyValue(property), null));
+            return value;
+        }
+
+        bool HasInputProvider(SerializedProperty property)
+        {
+            bool value = false;
+            PropertyInfo pi = typeof(AxisState).GetProperty(
+                "HasInputProvider", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
             if (pi != null)
                 value = bool.Equals(true, pi.GetValue(SerializedPropertyHelper.GetPropertyValue(property), null));
             return value;

--- a/Runtime/Behaviours/CinemachineFreeLook.cs
+++ b/Runtime/Behaviours/CinemachineFreeLook.cs
@@ -172,6 +172,22 @@ namespace Cinemachine
             mIsDestroyed = false;
             base.OnEnable();
             InvalidateRigCache();
+            UpdateInputAxisProvider();
+        }
+
+        /// <summary>
+        /// API for the inspector.  Internal use only
+        /// </summary>
+        public void UpdateInputAxisProvider()
+        {
+            m_XAxis.SetInputAxisProvider(0, null);
+            m_YAxis.SetInputAxisProvider(1, null);
+            var provider = GetInputAxisProvider();
+            if (provider != null)
+            {
+                m_XAxis.SetInputAxisProvider(0, provider);
+                m_YAxis.SetInputAxisProvider(1, provider);
+            }
         }
 
         /// <summary>Makes sure that the child rigs get destroyed in an undo-firndly manner.

--- a/Runtime/Components/CinemachineOrbitalTransposer.cs
+++ b/Runtime/Components/CinemachineOrbitalTransposer.cs
@@ -223,6 +223,22 @@ namespace Cinemachine
             // GML todo: do we really need this?
             PreviousTarget = null;
             mLastTargetPosition = Vector3.zero;
+
+            UpdateInputAxisProvider();
+        }
+
+        /// <summary>
+        /// API for the inspector.  Internal use only
+        /// </summary>
+        public void UpdateInputAxisProvider()
+        {
+            m_XAxis.SetInputAxisProvider(0, null);
+            if (!m_HeadingIsSlave && VirtualCamera != null)
+            {
+                var provider = VirtualCamera.GetInputAxisProvider();
+                if (provider != null)
+                    m_XAxis.SetInputAxisProvider(0, provider);
+            }
         }
 
         private Vector3 mLastTargetPosition = Vector3.zero;

--- a/Runtime/Components/CinemachinePOV.cs
+++ b/Runtime/Components/CinemachinePOV.cs
@@ -80,6 +80,29 @@ namespace Cinemachine
             m_HorizontalRecentering.Validate();
         }
 
+        private void OnEnable()
+        {
+            UpdateInputAxisProvider();
+        }
+        
+        /// <summary>
+        /// API for the inspector.  Internal use only
+        /// </summary>
+        public void UpdateInputAxisProvider()
+        {
+            m_HorizontalAxis.SetInputAxisProvider(0, null);
+            m_VerticalAxis.SetInputAxisProvider(1, null);
+            if (VirtualCamera != null)
+            {
+                var provider = VirtualCamera.GetInputAxisProvider();
+                if (provider != null)
+                {
+                    m_HorizontalAxis.SetInputAxisProvider(0, provider);
+                    m_VerticalAxis.SetInputAxisProvider(1, provider);
+                }
+            }
+        }
+
         /// <summary>Does nothing</summary>
         /// <param name="state"></param>
         /// <param name="deltaTime"></param>

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -492,6 +492,22 @@ namespace Cinemachine
             }
         }
 
+        /// <summary>
+        /// Locate the first component that implements AxisState.IInputAxisProvider.
+        /// </summary>
+        /// <returns>The first AxisState.IInputAxisProvider or null if none</returns>
+        public AxisState.IInputAxisProvider GetInputAxisProvider()
+        {
+            var components = GetComponentsInChildren<MonoBehaviour>();
+            for (int i = 0; i < components.Length; ++i)
+            {
+                var provider = components[i] as AxisState.IInputAxisProvider;
+                if (provider != null)
+                    return provider;
+            }
+            return null;
+        }
+
         /// <summary>Enforce bounds for fields, when changed in inspector.
         /// Call base class implementation at the beginning of overridden method.
         /// After base method is called, ValidatingStreamVersion will be valid.</summary>

--- a/Runtime/Experimental/CinemachineNewFreeLook.cs
+++ b/Runtime/Experimental/CinemachineNewFreeLook.cs
@@ -236,6 +236,28 @@ namespace Cinemachine
             m_RadialAxis.HasRecentering = false;
         }
 
+        /// <summary>Updates the child rig cache</summary>
+        protected override void OnEnable()
+        {
+            base.OnEnable();
+            UpdateInputAxisProvider();
+        }
+        
+        /// <summary>
+        /// API for the inspector.  Internal use only
+        /// </summary>
+        public void UpdateInputAxisProvider()
+        {
+            m_VerticalAxis.SetInputAxisProvider(0, null);
+            m_RadialAxis.SetInputAxisProvider(1, null);
+            var provider = GetInputAxisProvider();
+            if (provider != null)
+            {
+                m_VerticalAxis.SetInputAxisProvider(1, provider);
+                m_RadialAxis.SetInputAxisProvider(2, provider);
+            }
+        }
+        
         void Reset()
         {
             DestroyComponents();

--- a/Runtime/Helpers/CinemachineInputProvider.cs
+++ b/Runtime/Helpers/CinemachineInputProvider.cs
@@ -1,0 +1,96 @@
+﻿#if CINEMACHINE_UNITY_INPUTSYSTEM
+using System.Linq;
+using UnityEngine;
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.Users;
+
+namespace Cinemachine
+{
+    /// <summary>
+    /// This is an add-on to override the legacy input system and read input using the
+    /// UnityEngine.Input package API.  Add this behaviour to any CinemachineVirtualCamera 
+    /// or FreeLook that requires user input, and set it up to read the desired actions.
+    /// </summary>
+    public class CinemachineInputProvider : MonoBehaviour, AxisState.IInputAxisProvider
+    {
+        /// <summary>
+        /// Leave this at -1 for single-player games.
+        /// For multi-player games, set this to be the player index, and the actions will
+        /// be read from that player's controls
+        /// </summary>
+        public int PlayerIndex = -1;
+
+        /// <summary>Vector2 action for XY movement</summary>
+        public InputActionReference XYAxis;
+        /// <summary>Float action for Z movement</summary>
+        public InputActionReference ZAxis;
+
+        /// <summary>
+        /// Implementation of AxisState.IInputAxisProvider.GetAxisValue().
+        /// Axis index ranges from 0...2 for X, Y, and Z.
+        /// Reads the action associated with the axis.
+        /// </summary>
+        /// <param name="axis"></param>
+        /// <returns></returns>
+        public virtual float GetAxisValue(int axis)
+        {
+            var action = ResolveForPlayer(axis, axis == 2 ? ZAxis : XYAxis);
+            if (action == null)
+                return 0;
+            switch (axis)
+            {
+                case 0: return action.ReadValue<Vector2>().x;
+                case 1: return action.ReadValue<Vector2>().y;
+                case 2: return action.ReadValue<float>();
+            }
+            return 0;
+        }
+
+        const int NUM_AXES = 3;
+        InputAction[] m_cachedActions;
+
+        /// <summary>
+        /// In a multi-player context, actions are associated with specific players
+        /// This gets the appropriate action for the specified player
+        /// </summary>
+        /// <param name="axis">Which input axis (0, 1, or 2)</param>
+        /// <param name="actionRef">Which action reference to resolve</param>
+        /// <returns>The cached action for the player specified in PlayerIndex</returns>
+        protected InputAction ResolveForPlayer(int axis, InputActionReference actionRef)
+        {
+            if (axis < 0 || axis >= NUM_AXES)
+                return null;
+            if (actionRef == null || actionRef.action == null)
+                return null;
+            if (m_cachedActions == null || m_cachedActions.Length != NUM_AXES)
+                m_cachedActions = new InputAction[NUM_AXES];
+            if (m_cachedActions[axis] != null && actionRef.action.id != m_cachedActions[axis].id)
+                m_cachedActions[axis] = null;
+            if (m_cachedActions[axis] == null)
+            {
+                m_cachedActions[axis] = actionRef.action;
+                if (PlayerIndex != -1)
+                {
+                    var user = InputUser.all[PlayerIndex];
+                    m_cachedActions[axis] = user.actions.First(x => x.id == actionRef.action.id);
+                }
+            }
+            return m_cachedActions[axis];
+        }
+
+        // Clean up
+        private void OnDisable()
+        {
+            m_cachedActions = null;
+        }
+    }
+}
+#else
+using UnityEngine;
+
+namespace Cinemachine
+{
+    [AddComponentMenu("")] // Hide in menu
+    public class CinemachineInputProvider : MonoBehaviour {}
+}
+#endif

--- a/Runtime/Helpers/CinemachineInputProvider.cs
+++ b/Runtime/Helpers/CinemachineInputProvider.cs
@@ -9,7 +9,7 @@ namespace Cinemachine
     /// <summary>
     /// This is an add-on to override the legacy input system and read input using the
     /// UnityEngine.Input package API.  Add this behaviour to any CinemachineVirtualCamera 
-    /// or FreeLook that requires user input, and set it up to read the desired actions.
+    /// or FreeLook that requires user input, and drag in the the desired actions.
     /// </summary>
     public class CinemachineInputProvider : MonoBehaviour, AxisState.IInputAxisProvider
     {
@@ -18,11 +18,17 @@ namespace Cinemachine
         /// For multi-player games, set this to be the player index, and the actions will
         /// be read from that player's controls
         /// </summary>
+        [Tooltip("Leave this at -1 for single-player games.  "
+            + "For multi-player games, set this to be the player index, and the actions will "
+            + "be read from that player's controls")]
         public int PlayerIndex = -1;
 
         /// <summary>Vector2 action for XY movement</summary>
+        [Tooltip("Vector2 action for XY movement")]
         public InputActionReference XYAxis;
+
         /// <summary>Float action for Z movement</summary>
+        [Tooltip("Float action for Z movement")]
         public InputActionReference ZAxis;
 
         /// <summary>
@@ -31,17 +37,18 @@ namespace Cinemachine
         /// Reads the action associated with the axis.
         /// </summary>
         /// <param name="axis"></param>
-        /// <returns></returns>
+        /// <returns>The current axis value</returns>
         public virtual float GetAxisValue(int axis)
         {
             var action = ResolveForPlayer(axis, axis == 2 ? ZAxis : XYAxis);
-            if (action == null)
-                return 0;
-            switch (axis)
+            if (action != null)
             {
-                case 0: return action.ReadValue<Vector2>().x;
-                case 1: return action.ReadValue<Vector2>().y;
-                case 2: return action.ReadValue<float>();
+                switch (axis)
+                {
+                    case 0: return action.ReadValue<Vector2>().x;
+                    case 1: return action.ReadValue<Vector2>().y;
+                    case 2: return action.ReadValue<float>();
+                }
             }
             return 0;
         }
@@ -51,7 +58,10 @@ namespace Cinemachine
 
         /// <summary>
         /// In a multi-player context, actions are associated with specific players
-        /// This gets the appropriate action for the specified player
+        /// This resolves the appropriate action reference for the specified player.
+        /// 
+        /// Because the resolution involves a search, we also cache the returned 
+        /// action to make future resolutions faster.
         /// </summary>
         /// <param name="axis">Which input axis (0, 1, or 2)</param>
         /// <param name="actionRef">Which action reference to resolve</param>
@@ -75,6 +85,10 @@ namespace Cinemachine
                     m_cachedActions[axis] = user.actions.First(x => x.id == actionRef.action.id);
                 }
             }
+            // Auto-enable it if disabled
+            if (m_cachedActions[axis] != null && !m_cachedActions[axis].enabled)
+                m_cachedActions[axis].Enable();
+
             return m_cachedActions[axis];
         }
 

--- a/Runtime/Helpers/CinemachineInputProvider.cs.meta
+++ b/Runtime/Helpers/CinemachineInputProvider.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fb7194dc27b9df64c8beca7482ee8e0d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Runtime/com.unity.cinemachine.asmdef
+++ b/Runtime/com.unity.cinemachine.asmdef
@@ -7,7 +7,8 @@
         "Unity.RenderPipelines.HighDefinition.Runtime",
         "Unity.ugui",
         "Unity.RenderPipelines.Universal.Runtime",
-        "Unity.2D.PixelPerfect"
+        "Unity.2D.PixelPerfect",
+        "Unity.InputSystem"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],
@@ -71,6 +72,11 @@
             "name": "com.unity.2d.pixel-perfect",
             "expression": "2.0.3",
             "define": "CINEMACHINE_PIXEL_PERFECT_2_0_3"
+        },
+        {
+            "name": "com.unity.inputsystem",
+            "expression": "1.0.0-preview",
+            "define": "CINEMACHINE_UNITY_INPUTSYSTEM"
         }
     ],
     "noEngineReferences": false


### PR DESCRIPTION
Create a new hook for overriding the input system.  AxisState will call this, if present, instead of CinemachineCore.GetInputAxis().  It allows for a more generalized support of input systems, because the implementer can have extra state in their class.

An example implementation is CinemachineInputProvider, which implements for the UniteEngine.Input package

Feature description: https://docs.google.com/document/d/1yRLdDp0OVAQPQ2jjDwwxNg9nIkE13KokwnEDETSyzoo/edit#