### PR TITLE
Remove some GC allocs when in edit mode (reported by customer)

### DIFF
--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -144,7 +144,11 @@ namespace Cinemachine
             get
             {
                 if (m_OutputCamera == null && !Application.isPlaying)
+#if UNITY_2019_2_OR_NEWER
+                    TryGetComponent(out m_OutputCamera);
+#else
                     m_OutputCamera = GetComponent<Camera>();
+#endif
                 return m_OutputCamera;
             }
         }
@@ -814,7 +818,11 @@ namespace Cinemachine
     #if CINEMACHINE_HDRP
                     if (state.Lens.IsPhysicalCamera)
                     {
+#if UNITY_2019_2_OR_NEWER
+                        cam.TryGetComponent<HDAdditionalCameraData>(out var hda);
+#else
                         var hda = cam.GetComponent<HDAdditionalCameraData>();
+#endif
                         if (hda != null)
                         {
                             hda.physicalParameters.iso = state.Lens.Iso;

--- a/Runtime/Behaviours/CinemachineExternalCamera.cs
+++ b/Runtime/Behaviours/CinemachineExternalCamera.cs
@@ -52,8 +52,13 @@ namespace Cinemachine
         {
             // Get the state from the camera
             if (m_Camera == null)
+            {
+#if UNITY_2019_2_OR_NEWER
+                TryGetComponent(out m_Camera);
+#else
                 m_Camera = GetComponent<Camera>();
-
+#endif
+            }
             m_State = CameraState.Default;
             m_State.RawPosition = transform.position;
             m_State.RawOrientation = transform.rotation;

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -578,7 +578,13 @@ namespace Cinemachine
             m_parentVcam = null;
             Transform p = transform.parent;
             if (p != null)
+            {
+#if UNITY_2019_2_OR_NEWER
+                p.TryGetComponent(out m_parentVcam);
+#else
                 m_parentVcam = p.GetComponent<CinemachineVirtualCameraBase>();
+#endif
+            }
         }
 
         /// <summary>Returns this vcam's LookAt target, or if that is null, will retrun

--- a/Runtime/Core/LensSettings.cs
+++ b/Runtime/Core/LensSettings.cs
@@ -124,7 +124,11 @@ namespace Cinemachine
                 if (lens.IsPhysicalCamera)
                 {
                     var pc = new HDPhysicalCamera();
+#if UNITY_2019_2_OR_NEWER
+                    fromCamera.TryGetComponent<HDAdditionalCameraData>(out var hda);
+#else
                     var hda = fromCamera.GetComponent<HDAdditionalCameraData>();
+#endif
                     if (hda != null)
                         pc = hda.physicalParameters;
                     lens.Iso = pc.iso;

--- a/Runtime/PostProcessing/CinemachinePostProcessing.cs
+++ b/Runtime/PostProcessing/CinemachinePostProcessing.cs
@@ -276,8 +276,8 @@ namespace Cinemachine.PostFX
 
         static PostProcessLayer GetPPLayer(CinemachineBrain brain)
         {
-            PostProcessLayer layer = null;
-            if (mBrainToLayer.TryGetValue(brain, out layer))
+            bool found = mBrainToLayer.TryGetValue(brain, out PostProcessLayer layer);
+            if (found)
             {
 #if UNITY_EDITOR
                 // Maybe they added it since we last checked
@@ -285,12 +285,21 @@ namespace Cinemachine.PostFX
 #endif
                 return layer;
             }
+#if UNITY_2019_2_OR_NEWER
+            brain.TryGetComponent(out layer);
+#else
             layer = brain.GetComponent<PostProcessLayer>();
-            mBrainToLayer[brain] = layer;
-            if (layer != null)
-                brain.m_CameraCutEvent.AddListener(OnCameraCut);
-            else
+#endif
+            if (found)
+            {
+                mBrainToLayer.Remove(brain); // layer is null
                 brain.m_CameraCutEvent.RemoveListener(OnCameraCut);
+            }
+            else if (layer != null)
+            {
+                mBrainToLayer[brain] = layer;
+                brain.m_CameraCutEvent.AddListener(OnCameraCut);
+            }
             return layer;
         }
 

--- a/Runtime/PostProcessing/CinemachinePostProcessing.cs
+++ b/Runtime/PostProcessing/CinemachinePostProcessing.cs
@@ -277,28 +277,34 @@ namespace Cinemachine.PostFX
         static PostProcessLayer GetPPLayer(CinemachineBrain brain)
         {
             bool found = mBrainToLayer.TryGetValue(brain, out PostProcessLayer layer);
+            if (layer != null)
+                return layer;   // layer is valid and in our lookup
+
             if (found)
             {
-#if UNITY_EDITOR
-                // Maybe they added it since we last checked
-                if (layer != null || Application.isPlaying)
-#endif
-                return layer;
+                if (layer) // note: this is not the same check as (layer == null)
+                {
+                    // layer is a deleted object
+                    brain.m_CameraCutEvent.RemoveListener(OnCameraCut);
+                    mBrainToLayer.Remove(brain);
+                    layer = null;
+                }
             }
+            else
+            {
+                // Brain is not in our lookup - add it
 #if UNITY_2019_2_OR_NEWER
-            brain.TryGetComponent(out layer);
+                brain.TryGetComponent(out layer);
 #else
-            layer = brain.GetComponent<PostProcessLayer>();
+                layer = brain.GetComponent<PostProcessLayer>();
 #endif
-            if (found)
-            {
-                mBrainToLayer.Remove(brain); // layer is null
-                brain.m_CameraCutEvent.RemoveListener(OnCameraCut);
-            }
-            else if (layer != null)
-            {
-                mBrainToLayer[brain] = layer;
-                brain.m_CameraCutEvent.AddListener(OnCameraCut);
+                if (layer != null)
+                    brain.m_CameraCutEvent.AddListener(OnCameraCut); // valid layer
+#if UNITY_EDITOR
+                // Never add null in edit mode in case user adds a layer dynamically
+                if (Application.isPlaying)  
+#endif
+                    mBrainToLayer[brain] = layer;
             }
             return layer;
         }


### PR DESCRIPTION
Reported by customer.
Fixed for 2019.2 and up, using new TryGetComponent API