### PR TITLE
Regression Fix: PostProcessing/VolumeSettings FocusTracksTarget was…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: StateDrivenCamera was choosing parent state if only 1 clip in blendstate, even though there was a vcam assigned to that clip
 - Bugfix: brain updates on scene loaded or unloaded
 - Bugfix (1260385): check for prefab instances correctly
+- Regression Fix: PostProcessing/VolumeSettings FocusTracksTarget was not accounting for lookAt target offset
 
 ## [2.6.0] - 2020-06-04
 ### New Features and Bugfixes

--- a/Extras~/ReleaseNotes.txt
+++ b/Extras~/ReleaseNotes.txt
@@ -4,6 +4,7 @@
 - Bugfix: StateDrivenCamera was choosing parent state if only 1 clip in blendstate, even though there was a vcam assigned to that clip
 - Bugfix: brain updates on scene loaded or unloaded
 - Bugfix (1260385): check for prefab instances correctly
+- Regression Fix: PostProcessing/VolumeSettings FocusTracksTarget was not accounting for lookAt target offset
 
 <size=20><b>Version 2.6.0</b></size>
 - Added AxisState.IInputProvider API to better support custom input systems

--- a/Runtime/PostProcessing/CinemachinePostProcessing.cs
+++ b/Runtime/PostProcessing/CinemachinePostProcessing.cs
@@ -116,9 +116,9 @@ namespace Cinemachine.PostFX
                 list[i].DestroyProfileCopy();
         }
 
-        protected override void Awake()
+        protected override void OnEnable()
         {
-            base.Awake();
+            base.OnEnable();
 
             // Map legacy m_FocusTracksTarget to focus mode
             if (m_FocusTracksTarget)
@@ -162,16 +162,20 @@ namespace Cinemachine.PostFX
                         if (profile.TryGetSettings(out dof))
                         {
                             float focusDistance = m_FocusOffset;
-                            Transform focusTarget = null;
-                            switch (m_FocusTracking)
+                            if (m_FocusTracking == FocusTrackingMode.LookAtTarget)
+                                focusDistance += (state.FinalPosition - state.ReferenceLookAt).magnitude;
+                            else
                             {
-                                default: break;
-                                case FocusTrackingMode.LookAtTarget: focusTarget = VirtualCamera.LookAt; break;
-                                case FocusTrackingMode.FollowTarget: focusTarget = VirtualCamera.Follow; break;
-                                case FocusTrackingMode.CustomTarget: focusTarget = m_FocusTarget; break;
+                                Transform focusTarget = null;
+                                switch (m_FocusTracking)
+                                {
+                                    default: break;
+                                    case FocusTrackingMode.FollowTarget: focusTarget = VirtualCamera.Follow; break;
+                                    case FocusTrackingMode.CustomTarget: focusTarget = m_FocusTarget; break;
+                                }
+                                if (focusTarget != null)
+                                    focusDistance += (state.FinalPosition - focusTarget.position).magnitude;
                             }
-                            if (focusTarget != null)
-                                focusDistance += (state.FinalPosition - focusTarget.position).magnitude;
                             dof.focusDistance.value = Mathf.Max(0, focusDistance);
                         }
                     }

--- a/Runtime/PostProcessing/CinemachineVolumeSettings.cs
+++ b/Runtime/PostProcessing/CinemachineVolumeSettings.cs
@@ -121,9 +121,9 @@ namespace Cinemachine.PostFX
                 list[i].DestroyProfileCopy();
         }
 
-        protected override void Awake()
+        protected override void OnEnable()
         {
-            base.Awake();
+            base.OnEnable();
 
             // Map legacy m_FocusTracksTarget to focus mode
             if (m_FocusTracksTarget)
@@ -166,16 +166,20 @@ namespace Cinemachine.PostFX
                         if (profile.TryGet(out DepthOfField dof))
                         {
                             float focusDistance = m_FocusOffset;
-                            Transform focusTarget = null;
-                            switch (m_FocusTracking)
+                            if (m_FocusTracking == FocusTrackingMode.LookAtTarget)
+                                focusDistance += (state.FinalPosition - state.ReferenceLookAt).magnitude;
+                            else
                             {
-                                default: break;
-                                case FocusTrackingMode.LookAtTarget: focusTarget = VirtualCamera.LookAt; break;
-                                case FocusTrackingMode.FollowTarget: focusTarget = VirtualCamera.Follow; break;
-                                case FocusTrackingMode.CustomTarget: focusTarget = m_FocusTarget; break;
+                                Transform focusTarget = null;
+                                switch (m_FocusTracking)
+                                {
+                                    default: break;
+                                    case FocusTrackingMode.FollowTarget: focusTarget = VirtualCamera.Follow; break;
+                                    case FocusTrackingMode.CustomTarget: focusTarget = m_FocusTarget; break;
+                                }
+                                if (focusTarget != null)
+                                    focusDistance += (state.FinalPosition - focusTarget.position).magnitude;
                             }
-                            if (focusTarget != null)
-                                focusDistance += (state.FinalPosition - focusTarget.position).magnitude;
                             dof.focusDistance.value = Mathf.Max(0, focusDistance);
                             
                             profile.isDirty = true;


### PR DESCRIPTION
… not accounting for lookAt target offset

Bugfix for this issue reported on forum:
https://forum.unity.com/threads/cinemachine-2-6-dof-differs-from-the-2-5-version.922916/#post-6040763