### PR TITLE
[Editor] Enable multi-editing of Cinemachine components/extensions, where applicable

### DIFF
--- a/Editor/Editors/CinemachineBlendListCameraEditor.cs
+++ b/Editor/Editors/CinemachineBlendListCameraEditor.cs
@@ -44,17 +44,16 @@ namespace Cinemachine.Editor
             DrawTargetsInInspector(FindProperty(x => x.m_Follow), FindProperty(x => x.m_LookAt));
             DrawRemainingPropertiesInInspector();
 
-            // Instructions
-            UpdateCameraCandidates();
-            EditorGUI.BeginChangeCheck();
-            EditorGUILayout.Separator();
-            mInstructionList.DoLayoutList();
-
-            EditorGUILayout.Separator();
-
-            if (Selection.objects.Length == 1)
+            if (targets.Length == 1)
             {
-                
+                // Instructions
+                UpdateCameraCandidates();
+                EditorGUI.BeginChangeCheck();
+                EditorGUILayout.Separator();
+                mInstructionList.DoLayoutList();
+
+                EditorGUILayout.Separator();
+
                 mChildList.DoLayoutList();
                 if (EditorGUI.EndChangeCheck())
                 {

--- a/Editor/Editors/CinemachineBlendListCameraEditor.cs
+++ b/Editor/Editors/CinemachineBlendListCameraEditor.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 namespace Cinemachine.Editor
 {
     [CustomEditor(typeof(CinemachineBlendListCamera))]
+    [CanEditMultipleObjects]
     internal sealed class CinemachineBlendListCameraEditor
         : CinemachineVirtualCameraBaseEditor<CinemachineBlendListCamera>
     {
@@ -49,13 +50,21 @@ namespace Cinemachine.Editor
             EditorGUILayout.Separator();
             mInstructionList.DoLayoutList();
 
-            // vcam children
             EditorGUILayout.Separator();
-            mChildList.DoLayoutList();
-            if (EditorGUI.EndChangeCheck())
+
+            if (Selection.objects.Length == 1)
             {
-                serializedObject.ApplyModifiedProperties();
-                Target.ValidateInstructions();
+                
+                mChildList.DoLayoutList();
+                if (EditorGUI.EndChangeCheck())
+                {
+                    serializedObject.ApplyModifiedProperties();
+                    Target.ValidateInstructions();
+                }   
+            }
+            else
+            {
+                EditorGUILayout.HelpBox(Styles.virtualCameraChildrenInfoMsg.text, MessageType.Info);
             }
 
             // Extensions

--- a/Editor/Editors/CinemachineBrainEditor.cs
+++ b/Editor/Editors/CinemachineBrainEditor.cs
@@ -59,19 +59,22 @@ namespace Cinemachine.Editor
             // Normal properties
             DrawRemainingPropertiesInInspector();
 
-            // Blender
-            m_BlendsEditor.DrawEditorCombo(
-                "Create New Blender Asset",
-                Target.gameObject.name + " Blends", "asset", string.Empty,
-                "Custom Blends", false);
-
-            mEventsExpanded = EditorGUILayout.Foldout(mEventsExpanded, "Events", true);
-            if (mEventsExpanded)
+            if (targets.Length == 1)
             {
-                EditorGUILayout.PropertyField(FindProperty(x => x.m_CameraCutEvent));
-                EditorGUILayout.PropertyField(FindProperty(x => x.m_CameraActivatedEvent));
+                // Blender
+                m_BlendsEditor.DrawEditorCombo(
+                    "Create New Blender Asset",
+                    Target.gameObject.name + " Blends", "asset", string.Empty,
+                    "Custom Blends", false);
+
+                mEventsExpanded = EditorGUILayout.Foldout(mEventsExpanded, "Events", true);
+                if (mEventsExpanded)
+                {
+                    EditorGUILayout.PropertyField(FindProperty(x => x.m_CameraCutEvent));
+                    EditorGUILayout.PropertyField(FindProperty(x => x.m_CameraActivatedEvent));
+                }
+                serializedObject.ApplyModifiedProperties(); 
             }
-            serializedObject.ApplyModifiedProperties();
         }
 
         [DrawGizmo(GizmoType.Selected | GizmoType.NonSelected, typeof(CinemachineBrain))]

--- a/Editor/Editors/CinemachineBrainEditor.cs
+++ b/Editor/Editors/CinemachineBrainEditor.cs
@@ -7,6 +7,7 @@ using System.IO;
 namespace Cinemachine.Editor
 {
     [CustomEditor(typeof(CinemachineBrain))]
+    [CanEditMultipleObjects]
     public sealed class CinemachineBrainEditor : BaseEditor<CinemachineBrain>
     {
         EmbeddeAssetEditor<CinemachineBlenderSettings> m_BlendsEditor;

--- a/Editor/Editors/CinemachineClearShotEditor.cs
+++ b/Editor/Editors/CinemachineClearShotEditor.cs
@@ -10,6 +10,7 @@ namespace Cinemachine.Editor
 {
 #if CINEMACHINE_PHYSICS
     [CustomEditor(typeof(CinemachineClearShot))]
+    [CanEditMultipleObjects]
     internal sealed class CinemachineClearShotEditor
         : CinemachineVirtualCameraBaseEditor<CinemachineClearShot>
     {
@@ -85,11 +86,19 @@ namespace Cinemachine.Editor
 
             // vcam children
             EditorGUILayout.Separator();
-            EditorGUI.BeginChangeCheck();
-            mChildList.DoLayoutList();
-            if (EditorGUI.EndChangeCheck())
-                serializedObject.ApplyModifiedProperties();
 
+            if (Selection.objects.Length == 1)
+            {
+                EditorGUI.BeginChangeCheck();
+                mChildList.DoLayoutList();
+                if (EditorGUI.EndChangeCheck())
+                    serializedObject.ApplyModifiedProperties();
+            }
+            else
+            {
+                EditorGUILayout.HelpBox(Styles.virtualCameraChildrenInfoMsg.text, MessageType.Info);
+            }
+            
             // Extensions
             DrawExtensionsWidgetInInspector();
         }

--- a/Editor/Editors/CinemachineColliderEditor.cs
+++ b/Editor/Editors/CinemachineColliderEditor.cs
@@ -11,6 +11,7 @@ namespace Cinemachine.Editor
 {
 #if CINEMACHINE_PHYSICS
     [CustomEditor(typeof(CinemachineCollider))]
+    [CanEditMultipleObjects]
     internal sealed class CinemachineColliderEditor : BaseEditor<CinemachineCollider>
     {
         protected override void GetExcludedPropertiesInInspector(List<string> excluded)

--- a/Editor/Editors/CinemachineConfinerEditor.cs
+++ b/Editor/Editors/CinemachineConfinerEditor.cs
@@ -12,6 +12,7 @@ namespace Cinemachine.Editor
 {
 #if CINEMACHINE_PHYSICS || CINEMACHINE_PHYSICS_2D
     [CustomEditor(typeof(CinemachineConfiner))]
+    [CanEditMultipleObjects]
     internal sealed class CinemachineConfinerEditor : BaseEditor<CinemachineConfiner>
     {
         protected override void GetExcludedPropertiesInInspector(List<string> excluded)

--- a/Editor/Editors/CinemachineExternalCameraEditor.cs
+++ b/Editor/Editors/CinemachineExternalCameraEditor.cs
@@ -4,6 +4,7 @@ using UnityEditor;
 namespace Cinemachine.Editor
 {
     [CustomEditor(typeof(CinemachineExternalCamera))]
+    [CanEditMultipleObjects]
     internal class CinemachineExternalCameraEditor 
         : CinemachineVirtualCameraBaseEditor<CinemachineExternalCamera>
     {

--- a/Editor/Editors/CinemachineFreeLookEditor.cs
+++ b/Editor/Editors/CinemachineFreeLookEditor.cs
@@ -7,6 +7,7 @@ using Cinemachine.Utility;
 namespace Cinemachine
 {
     [CustomEditor(typeof(CinemachineFreeLook))]
+    [CanEditMultipleObjects]
     internal sealed class CinemachineFreeLookEditor
         : CinemachineVirtualCameraBaseEditor<CinemachineFreeLook>
     {
@@ -69,20 +70,23 @@ namespace Cinemachine
                 serializedObject.ApplyModifiedProperties();
 
             // Rigs
-            UpdateRigEditors();
-            for (int i = 0; i < m_editors.Length; ++i)
+            if (Selection.objects.Length == 1)
             {
-                if (m_editors[i] == null)
-                    continue;
-                EditorGUILayout.Separator();
-                EditorGUILayout.BeginVertical(GUI.skin.box);
-                EditorGUILayout.LabelField(RigNames[i], EditorStyles.boldLabel);
-                ++EditorGUI.indentLevel;
-                m_editors[i].OnInspectorGUI();
-                --EditorGUI.indentLevel;
-                EditorGUILayout.EndVertical();
+                UpdateRigEditors();
+                for (int i = 0; i < m_editors.Length; ++i)
+                {
+                    if (m_editors[i] == null)
+                        continue;
+                    EditorGUILayout.Separator();
+                    EditorGUILayout.BeginVertical(GUI.skin.box);
+                    EditorGUILayout.LabelField(RigNames[i], EditorStyles.boldLabel);
+                    ++EditorGUI.indentLevel;
+                    m_editors[i].OnInspectorGUI();
+                    --EditorGUI.indentLevel;
+                    EditorGUILayout.EndVertical();
+                }
             }
-
+            
             // Extensions
             DrawExtensionsWidgetInInspector();
         }

--- a/Editor/Editors/CinemachineStoryboardEditor.cs
+++ b/Editor/Editors/CinemachineStoryboardEditor.cs
@@ -59,6 +59,23 @@ namespace Cinemachine.Editor
         const float FastWaveformUpdateInterval = 0.1f;
         float mLastSplitScreenEventTime = 0;
 
+        bool AreSyncToggleValuesDifferentInSelection(SerializedProperty property)
+        {
+            var so = new SerializedObject(serializedObject.targetObjects[0]);
+            SerializedProperty prop = so.FindProperty(property.propertyPath);
+            var initialValue = prop.boolValue;
+            
+            for(int i = 1; i  < serializedObject.targetObjects.Length; i++)
+            {
+                so = new SerializedObject(serializedObject.targetObjects[i]);
+                prop = so.FindProperty(property.propertyPath);
+                if (initialValue != prop.boolValue)
+                    return true;
+            }
+
+            return false;
+        }
+        
         public override void OnInspectorGUI()
         {
             float now = Time.realtimeSinceStartup;
@@ -94,7 +111,9 @@ namespace Cinemachine.Editor
                 rect.width /= 3;
                 var prop = FindProperty(x => x.m_SyncScale);
                 GUIContent syncLabel = new GUIContent("Sync", prop.tooltip);
+                EditorGUI.showMixedValue = AreSyncToggleValuesDifferentInSelection(prop); // prop.hasMultipleDifferentValues is always false here for some reason, thus this function
                 prop.boolValue = EditorGUI.ToggleLeft(rect, syncLabel, prop.boolValue);
+                EditorGUI.showMixedValue = false;
                 rect.x += rect.width;
                 if (prop.boolValue)
                 {

--- a/Editor/Editors/CinemachineStoryboardEditor.cs
+++ b/Editor/Editors/CinemachineStoryboardEditor.cs
@@ -48,6 +48,7 @@ namespace Cinemachine.Editor
     }
 
     [CustomEditor(typeof(CinemachineStoryboard))]
+    [CanEditMultipleObjects]
     internal sealed class CinemachineStoryboardEditor : BaseEditor<CinemachineStoryboard>
     {
         public void OnDisable()

--- a/Editor/Editors/CinemachineStoryboardEditor.cs
+++ b/Editor/Editors/CinemachineStoryboardEditor.cs
@@ -58,23 +58,6 @@ namespace Cinemachine.Editor
 
         const float FastWaveformUpdateInterval = 0.1f;
         float mLastSplitScreenEventTime = 0;
-
-        bool AreSyncToggleValuesDifferentInSelection(SerializedProperty property)
-        {
-            var so = new SerializedObject(serializedObject.targetObjects[0]);
-            SerializedProperty prop = so.FindProperty(property.propertyPath);
-            var initialValue = prop.boolValue;
-            
-            for(int i = 1; i  < serializedObject.targetObjects.Length; i++)
-            {
-                so = new SerializedObject(serializedObject.targetObjects[i]);
-                prop = so.FindProperty(property.propertyPath);
-                if (initialValue != prop.boolValue)
-                    return true;
-            }
-
-            return false;
-        }
         
         public override void OnInspectorGUI()
         {
@@ -109,23 +92,30 @@ namespace Cinemachine.Editor
                 EditorGUI.LabelField(rect, "Scale");
                 rect.x += EditorGUIUtility.labelWidth; rect.width -= EditorGUIUtility.labelWidth;
                 rect.width /= 3;
+                serializedObject.SetIsDifferentCacheDirty(); // prop.hasMultipleDifferentValues always results in false if the SO isn't refreshed here
                 var prop = FindProperty(x => x.m_SyncScale);
+                var syncHasDifferentValues = prop.hasMultipleDifferentValues;
                 GUIContent syncLabel = new GUIContent("Sync", prop.tooltip);
-                EditorGUI.showMixedValue = AreSyncToggleValuesDifferentInSelection(prop); // prop.hasMultipleDifferentValues is always false here for some reason, thus this function
+                EditorGUI.showMixedValue = syncHasDifferentValues;
                 prop.boolValue = EditorGUI.ToggleLeft(rect, syncLabel, prop.boolValue);
                 EditorGUI.showMixedValue = false;
                 rect.x += rect.width;
-                if (prop.boolValue)
+                if (prop.boolValue || targets.Length > 1 && syncHasDifferentValues)
                 {
                     prop = FindProperty(x => x.m_Scale);
                     float[] values = new float[1] { prop.vector2Value.x };
+                    EditorGUI.showMixedValue = prop.hasMultipleDifferentValues;
                     EditorGUI.MultiFloatField(rect, new GUIContent[1] { new GUIContent("X") }, values);
+                    EditorGUI.showMixedValue = false;
                     prop.vector2Value = new Vector2(values[0], values[0]);
                 }
                 else
                 {
                     rect.width *= 2;
-                    EditorGUI.PropertyField(rect, FindProperty(x => x.m_Scale), GUIContent.none);
+                    prop = FindProperty(x => x.m_Scale);
+                    EditorGUI.showMixedValue = prop.hasMultipleDifferentValues;
+                    EditorGUI.PropertyField(rect, prop, GUIContent.none);
+                    EditorGUI.showMixedValue = false;
                 }
                 EditorGUILayout.PropertyField(FindProperty(x => x.m_MuteCamera));
             }

--- a/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
@@ -3,6 +3,7 @@ using UnityEditor;
 using System;
 using System.Collections.Generic;
 using Cinemachine.Utility;
+using UnityEngine.UIElements;
 
 namespace Cinemachine.Editor
 {
@@ -13,6 +14,12 @@ namespace Cinemachine.Editor
     public class CinemachineVirtualCameraBaseEditor<T>
         : BaseEditor<T> where T : CinemachineVirtualCameraBase
     {
+        public static class Styles
+        {
+            public static GUIContent addExtensionLabel = new GUIContent("Add Extension");
+            public static GUIContent virtualCameraChildrenInfoMsg = new GUIContent("The Virtual Camera Children field displays the child objects of a given parent object, thus this field is not available when multiple objects are selected.");
+        }
+        
         static Type[] sExtensionTypes;  // First entry is null
         static string[] sExtensionNames;
         bool IsPrefabBase { get; set; }
@@ -111,14 +118,27 @@ namespace Cinemachine.Editor
                 EditorGUILayout.Space();
                 EditorGUILayout.LabelField("Extensions", EditorStyles.boldLabel);
                 Rect rect = EditorGUILayout.GetControlRect(true, EditorGUIUtility.singleLineHeight);
-                rect = EditorGUI.PrefixLabel(rect, new GUIContent("Add Extension"));
+                rect = EditorGUI.PrefixLabel(rect, Styles.addExtensionLabel);
 
                 int selection = EditorGUI.Popup(rect, 0, sExtensionNames);
                 if (selection > 0)
                 {
                     Type extType = sExtensionTypes[selection];
-                    if (Target.GetComponent(extType) == null)
-                        Undo.AddComponent(Target.gameObject, extType);
+
+                    if (Selection.objects.Length == 1)
+                    {
+                        if (Target.GetComponent(extType) == null)
+                            Undo.AddComponent(Target.gameObject, extType);
+                    }
+                    else
+                    {
+                        for (int i = 0; i < targets.Length; i++)
+                        {
+                            var targetGO = (targets[i] as CinemachineVirtualCameraBase).gameObject; 
+                            if (targetGO != null && targetGO.GetComponent(extType) == null)
+                                Undo.AddComponent(targetGO, extType);
+                        }
+                    }
                 }
                 ExcludeProperty("Extensions");
             }
@@ -126,6 +146,9 @@ namespace Cinemachine.Editor
 
         protected void DrawCameraStatusInInspector()
         {
+            if (Selection.objects.Length > 1)
+                return;
+            
             // Is the camera navel-gazing?
             CameraState state = Target.State;
             if (state.HasLookAt && (state.ReferenceLookAt - state.CorrectedPosition).AlmostZero())

--- a/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraBaseEditor.cs
@@ -3,7 +3,6 @@ using UnityEditor;
 using System;
 using System.Collections.Generic;
 using Cinemachine.Utility;
-using UnityEngine.UIElements;
 
 namespace Cinemachine.Editor
 {
@@ -17,7 +16,7 @@ namespace Cinemachine.Editor
         public static class Styles
         {
             public static GUIContent addExtensionLabel = new GUIContent("Add Extension");
-            public static GUIContent virtualCameraChildrenInfoMsg = new GUIContent("The Virtual Camera Children field displays the child objects of a given parent object, thus this field is not available when multiple objects are selected.");
+            public static GUIContent virtualCameraChildrenInfoMsg = new GUIContent("The Virtual Camera Children field is not available when multiple objects are selected.");
         }
         
         static Type[] sExtensionTypes;  // First entry is null
@@ -124,20 +123,11 @@ namespace Cinemachine.Editor
                 if (selection > 0)
                 {
                     Type extType = sExtensionTypes[selection];
-
-                    if (Selection.objects.Length == 1)
+                    for (int i = 0; i < targets.Length; i++)
                     {
-                        if (Target.GetComponent(extType) == null)
-                            Undo.AddComponent(Target.gameObject, extType);
-                    }
-                    else
-                    {
-                        for (int i = 0; i < targets.Length; i++)
-                        {
-                            var targetGO = (targets[i] as CinemachineVirtualCameraBase).gameObject; 
-                            if (targetGO != null && targetGO.GetComponent(extType) == null)
-                                Undo.AddComponent(targetGO, extType);
-                        }
+                        var targetGO = (targets[i] as CinemachineVirtualCameraBase).gameObject;
+                        if (targetGO != null && targetGO.GetComponent(extType) == null)
+                            Undo.AddComponent(targetGO, extType);
                     }
                 }
                 ExcludeProperty("Extensions");

--- a/Editor/Editors/CinemachineVirtualCameraEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraEditor.cs
@@ -284,7 +284,8 @@ namespace Cinemachine.Editor
             // Get the existing components
             for(int j = 0; j < targets.Length; j++)
             {
-                Transform owner = (targets[j] as CinemachineVirtualCamera).GetComponentOwner();
+                var vCam = targets[j] as CinemachineVirtualCamera;
+                Transform owner = vCam.GetComponentOwner();
                 if (owner == null)
                     continue; // maybe it's a prefab
 
@@ -316,6 +317,8 @@ namespace Cinemachine.Editor
                 if (type != null)
                 {
                     MonoBehaviour b = Undo.AddComponent(owner.gameObject, type) as MonoBehaviour;
+                    vCam.m_Stages[(int)stage] = b as CinemachineComponentBase;
+
                     while (numComponents-- > insertPoint)
                         UnityEditorInternal.ComponentUtility.MoveComponentDown(b);
                 }
@@ -406,10 +409,9 @@ namespace Cinemachine.Editor
         {
             // Invalidate the target's cache - this is to support Undo
             Target.InvalidateComponentPipeline();
+            UpdateStageDataTypeMatchesForMultiSelection();
             UpdateComponentEditors();
             UpdateStageState(m_components);
-
-            UpdateStageDataTypeMatchesForMultiSelection();
         }
 
         // This code dynamically builds editors for the pipeline components.

--- a/Editor/Editors/CinemachineVirtualCameraEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraEditor.cs
@@ -9,6 +9,7 @@ using System.Linq;
 namespace Cinemachine.Editor
 {
     [CustomEditor(typeof(CinemachineVirtualCamera))]
+    [CanEditMultipleObjects]
     internal class CinemachineVirtualCameraEditor
         : CinemachineVirtualCameraBaseEditor<CinemachineVirtualCamera>
     {

--- a/Editor/Editors/CinemachineVirtualCameraEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraEditor.cs
@@ -27,7 +27,7 @@ namespace Cinemachine.Editor
             public GUIContent[] PopupOptions;
         }
         static StageData[] sStageData = null;
-        bool[] m_hasSameStageDataTypes = null;
+        bool[] m_hasSameStageDataTypes = new bool[Enum.GetValues(typeof(CinemachineCore.Stage)).Length];
 
         // Instance data - call UpdateInstanceData() to refresh this
         int[] m_stageState = null;
@@ -41,6 +41,7 @@ namespace Cinemachine.Editor
             // Build static menu arrays via reflection
             base.OnEnable();
             IsPrefab = Target.gameObject.scene.name == null; // causes a small GC alloc
+
             UpdateStaticData();
             UpdateStageDataTypeMatchesForMultiSelection();
             Undo.undoRedoPerformed += ResetTargetOnUndo;
@@ -405,11 +406,11 @@ namespace Cinemachine.Editor
 
         void UpdateStageDataTypeMatchesForMultiSelection()
         {
-            m_hasSameStageDataTypes = new bool[Enum.GetValues(typeof(CinemachineCore.Stage)).Length];
-            m_hasSameStageDataTypes = m_hasSameStageDataTypes.Select(t => t = true).ToArray();
-
             if (targets.Length == 1)
+            {
+                m_hasSameStageDataTypes = m_hasSameStageDataTypes.Select(t => t = true).ToArray();
                 return;
+            }
 
             var sortedPipelineForFirstTarget = GetSortedPipelineComponentsForCamera(serializedObject.targetObjects[0]);
 
@@ -424,7 +425,9 @@ namespace Cinemachine.Editor
 
                     if (sortedPipelineForFirstTarget[index] == null || sortedPipelineForSecondTarget[index] == null)
                         m_hasSameStageDataTypes[index] = sortedPipelineForFirstTarget[index] == null && sortedPipelineForSecondTarget[index] == null;
-                    else (sortedPipelineForFirstTarget[index].GetType() != sortedPipelineForSecondTarget[index].GetType())
+                    else if (sortedPipelineForFirstTarget[index].GetType() == sortedPipelineForSecondTarget[index].GetType())
+                        m_hasSameStageDataTypes[index] = true;
+                    else
                         m_hasSameStageDataTypes[index] = false;
                 }
             }

--- a/Editor/Editors/CinemachineVirtualCameraEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraEditor.cs
@@ -391,7 +391,8 @@ namespace Cinemachine.Editor
                 }
 
                 var behaviourArray = behaviours.ToArray();
-                hasSameStageDataTypes[i] = CheckIfComponentTypesMatch(behaviourArray);
+                if(behaviourArray.Length > 0 && behaviourArray[0] != null)
+                    hasSameStageDataTypes[i] = CheckIfComponentTypesMatch(behaviourArray);
             }
         }
 

--- a/Editor/Editors/CinemachineVirtualCameraEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraEditor.cs
@@ -418,7 +418,8 @@ namespace Cinemachine.Editor
             for (int i = 0; i < targets.Length; i++)
             {
                 var cam = targets[i] as CinemachineVirtualCamera;
-                cam?.InvalidateComponentPipeline();
+                if(cam != null)
+                    cam.InvalidateComponentPipeline();
             }
             UpdateStageDataTypeMatchesForMultiSelection();
             UpdateComponentEditors();

--- a/Editor/Impulse/CinemachineImpulseChannelPropertyDrawer.cs
+++ b/Editor/Impulse/CinemachineImpulseChannelPropertyDrawer.cs
@@ -33,12 +33,16 @@ namespace Cinemachine.Editor
             UpdateLayerList();
             float addWidth = GUI.skin.button.CalcSize(mAddLabel).x;
             rect.width -= addWidth + hSpace;
+            
+            EditorGUI.showMixedValue = property.hasMultipleDifferentValues;
+            EditorGUI.BeginChangeCheck();
             int value = EditorGUI.MaskField(rect, label, property.intValue, mLayerList);
-            if (value != property.intValue)
+            if (EditorGUI.EndChangeCheck())
             {
                 property.intValue  = value;
                 property.serializedObject.ApplyModifiedProperties();
             }
+            EditorGUI.showMixedValue = false;
 
             rect.x += rect.width + hSpace; rect.width = addWidth; rect.height -= 1;
             if (GUI.Button(rect, mAddLabel))

--- a/Editor/Impulse/CinemachineImpulseListenerEditor.cs
+++ b/Editor/Impulse/CinemachineImpulseListenerEditor.cs
@@ -3,6 +3,7 @@
 namespace Cinemachine.Editor
 {
     [CustomEditor(typeof(CinemachineImpulseListener))]
+    [CanEditMultipleObjects]
     internal sealed class CinemachineImpulseListenerEditor 
         : BaseEditor<CinemachineImpulseListener>
     {

--- a/Editor/PropertyDrawers/CinemachineTagFieldPropertyDrawer.cs
+++ b/Editor/PropertyDrawers/CinemachineTagFieldPropertyDrawer.cs
@@ -7,23 +7,30 @@ namespace Cinemachine.Editor
     internal sealed class CinemachineTagFieldPropertyDrawer : PropertyDrawer
     {
         const float hSpace = 2;
+        private string tagValue = "";
         GUIContent clearText = new GUIContent("Clear", "Set the tag to empty");
-
+        
         public override void OnGUI(Rect rect, SerializedProperty property, GUIContent label)
         {
             var textDimensions = GUI.skin.button.CalcSize(clearText);
 
             rect.width -= textDimensions.x + hSpace;
-            string oldValue = property.stringValue;
-            string newValue = EditorGUI.TagField(rect, label, oldValue);
+            
+            tagValue = property.stringValue;
+            EditorGUI.showMixedValue = property.hasMultipleDifferentValues;
+            EditorGUI.BeginChangeCheck();
+            tagValue = EditorGUI.TagField(rect, label, tagValue);
+            if (EditorGUI.EndChangeCheck())
+            {
+                property.stringValue = tagValue;
+            }
+            EditorGUI.showMixedValue = false;
 
             rect.x += rect.width + hSpace; rect.width = textDimensions.x; rect.height -=1;
-            GUI.enabled = oldValue.Length > 0;
+            GUI.enabled = tagValue.Length > 0;
             if (GUI.Button(rect, clearText))
-                newValue = string.Empty;
+                tagValue = string.Empty;
             GUI.enabled = true;
-            if (oldValue != newValue)
-                property.stringValue = newValue;
         }
     }
 }

--- a/Editor/PropertyDrawers/NoiseSettingsPropertyDrawer.cs
+++ b/Editor/PropertyDrawers/NoiseSettingsPropertyDrawer.cs
@@ -14,7 +14,9 @@ namespace Cinemachine.Editor
             float iconSize = rect.height + 4;
             rect.width -= iconSize;
             int preset = sNoisePresets.IndexOf((NoiseSettings)property.objectReferenceValue);
+            EditorGUI.showMixedValue = property.hasMultipleDifferentValues;
             preset = EditorGUI.Popup(rect, label, preset, sNoisePresetNames);
+            EditorGUI.showMixedValue = false;
             string labelText = label.text;
             NoiseSettings newProfile = preset < 0 ? null : sNoisePresets[preset] as NoiseSettings;
             if ((NoiseSettings)property.objectReferenceValue != newProfile)

--- a/Runtime/Behaviours/CinemachineVirtualCamera.cs
+++ b/Runtime/Behaviours/CinemachineVirtualCamera.cs
@@ -96,6 +96,10 @@ namespace Cinemachine
         [FormerlySerializedAs("m_BlendHint")]
         [FormerlySerializedAs("m_PositionBlending")] private BlendHint m_LegacyBlendHint;
 
+        [SerializeField]
+        [HideInInspector]
+        internal CinemachineComponentBase[] m_Stages;
+        
         /// <summary>This is the name of the hidden GameObject that will be created as a child object
         /// of the virtual camera.  This hidden game object acts as a container for the polymorphic
         /// CinemachineComponent pipeline.  The Inspector UI for the Virtual Camera
@@ -176,6 +180,8 @@ namespace Cinemachine
                 if (LookAt != null && GetCinemachineComponent(CinemachineCore.Stage.Aim) == null)
                     AddCinemachineComponent<CinemachineHardLookAt>();
             }
+
+            m_Stages = new CinemachineComponentBase[3];
         }
 
         /// <summary>Calls the DestroyPipelineDelegate for destroying the hidden
@@ -439,6 +445,17 @@ namespace Cinemachine
                 // Sort the pipeline
                 list.Sort((c1, c2) => (int)c1.Stage - (int)c2.Stage);
                 m_ComponentPipeline = list.ToArray();
+            }
+
+            // update serialized stage properties with changed data
+            Dictionary<CinemachineCore.Stage, CinemachineComponentBase> componentToStageMap = new Dictionary<CinemachineCore.Stage, CinemachineComponentBase>();
+            foreach (CinemachineComponentBase c in m_ComponentPipeline)
+                componentToStageMap.Add(c.Stage, c);
+
+            foreach (CinemachineCore.Stage stage in System.Enum.GetValues(typeof(CinemachineCore.Stage))) 
+            {
+                if (componentToStageMap.ContainsKey(stage))
+                    m_Stages[(int)stage] = componentToStageMap[stage];
             }
         }
 

--- a/Runtime/Behaviours/CinemachineVirtualCamera.cs
+++ b/Runtime/Behaviours/CinemachineVirtualCamera.cs
@@ -95,10 +95,6 @@ namespace Cinemachine
         [SerializeField] [HideInInspector]
         [FormerlySerializedAs("m_BlendHint")]
         [FormerlySerializedAs("m_PositionBlending")] private BlendHint m_LegacyBlendHint;
-
-        [SerializeField]
-        [HideInInspector]
-        internal CinemachineComponentBase[] m_Stages;
         
         /// <summary>This is the name of the hidden GameObject that will be created as a child object
         /// of the virtual camera.  This hidden game object acts as a container for the polymorphic
@@ -180,8 +176,6 @@ namespace Cinemachine
                 if (LookAt != null && GetCinemachineComponent(CinemachineCore.Stage.Aim) == null)
                     AddCinemachineComponent<CinemachineHardLookAt>();
             }
-
-            m_Stages = new CinemachineComponentBase[3];
         }
 
         /// <summary>Calls the DestroyPipelineDelegate for destroying the hidden
@@ -445,17 +439,6 @@ namespace Cinemachine
                 // Sort the pipeline
                 list.Sort((c1, c2) => (int)c1.Stage - (int)c2.Stage);
                 m_ComponentPipeline = list.ToArray();
-            }
-
-            // update serialized stage properties with changed data
-            Dictionary<CinemachineCore.Stage, CinemachineComponentBase> componentToStageMap = new Dictionary<CinemachineCore.Stage, CinemachineComponentBase>();
-            foreach (CinemachineComponentBase c in m_ComponentPipeline)
-                componentToStageMap.Add(c.Stage, c);
-
-            foreach (CinemachineCore.Stage stage in System.Enum.GetValues(typeof(CinemachineCore.Stage))) 
-            {
-                if (componentToStageMap.ContainsKey(stage))
-                    m_Stages[(int)stage] = componentToStageMap[stage];
             }
         }
 

--- a/Runtime/Components/CinemachineComposer.cs
+++ b/Runtime/Components/CinemachineComposer.cs
@@ -191,7 +191,7 @@ namespace Cinemachine
 
         public override void PrePipelineMutateCameraState(ref CameraState curState, float deltaTime)
         {
-            if (this != null && IsValid && curState.HasLookAt)
+            if (IsValid && curState.HasLookAt)
                 curState.ReferenceLookAt = GetLookAtPointAndSetTrackedPoint(
                     curState.ReferenceLookAt, curState.ReferenceUp, deltaTime);
         }

--- a/Runtime/Components/CinemachineComposer.cs
+++ b/Runtime/Components/CinemachineComposer.cs
@@ -191,7 +191,7 @@ namespace Cinemachine
 
         public override void PrePipelineMutateCameraState(ref CameraState curState, float deltaTime)
         {
-            if (IsValid && curState.HasLookAt)
+            if (this != null && IsValid && curState.HasLookAt)
                 curState.ReferenceLookAt = GetLookAtPointAndSetTrackedPoint(
                     curState.ReferenceLookAt, curState.ReferenceUp, deltaTime);
         }


### PR DESCRIPTION
-----
### Purpose of this PR

Added multi-selection support to Cinemachine editors where it made sense, including:

- Virtual Camera
- Free Look Camera
- Blend List, Clear Shot Cameras (support is limited due to these pointing to child objects of the GO to which the camera component is attached, thus there is no multi-editing for that)
- All of the Extensions
------
### Testing status

Tested manually to work when handling multiple objects by myself and our internal team QA.

### Screenshots
![CinemachineMultiEdti](https://user-images.githubusercontent.com/17855501/88146768-f294e080-cc04-11ea-8f27-b9204a6796c1.png)



