### PR TITLE
Optimize path gizmos

### DIFF
--- a/Editor/Editors/CinemachinePathEditor.cs
+++ b/Editor/Editors/CinemachinePathEditor.cs
@@ -389,24 +389,27 @@ namespace Cinemachine.Editor
             Color colorOld = Gizmos.color;
             Gizmos.color = pathColor;
             float step = 1f / path.m_Resolution;
+            float halfWidth = path.m_Appearance.width * 0.5f;
             Vector3 lastPos = path.EvaluatePosition(path.MinPos);
             Vector3 lastW = (path.EvaluateOrientation(path.MinPos)
-                             * Vector3.right) * path.m_Appearance.width / 2;
-            for (float t = path.MinPos + step; t <= path.MaxPos + step / 2; t += step)
+                             * Vector3.right) * halfWidth;
+            float tEnd = path.MaxPos + step / 2;
+            for (float t = path.MinPos + step; t <= tEnd; t += step)
             {
                 Vector3 p = path.EvaluatePosition(t);
                 Quaternion q = path.EvaluateOrientation(t);
-                Vector3 w = (q * Vector3.right) * path.m_Appearance.width / 2;
+                Vector3 w = (q * Vector3.right) * halfWidth;
                 Vector3 w2 = w * 1.2f;
                 Vector3 p0 = p - w2;
                 Vector3 p1 = p + w2;
                 Gizmos.DrawLine(p0, p1);
                 Gizmos.DrawLine(lastPos - lastW, p - w);
                 Gizmos.DrawLine(lastPos + lastW, p + w);
+
 #if false
                 // Show the normals, for debugging
                 Gizmos.color = Color.red;
-                Vector3 y = (q * Vector3.up) * path.m_Appearance.width / 2;
+                Vector3 y = (q * Vector3.up) * halfWidth;
                 Gizmos.DrawLine(p, p + y);
                 Gizmos.color = pathColor;
 #endif

--- a/Editor/Editors/CinemachinePathEditor.cs
+++ b/Editor/Editors/CinemachinePathEditor.cs
@@ -383,7 +383,7 @@ namespace Cinemachine.Editor
             }
         }
 
-        public static void DrawPathGizmo(CinemachinePathBase path, Color pathColor)
+        public static void DrawPathGizmo(CinemachinePathBase path, Color pathColor, bool isActive)
         {
             // Draw the path
             Color colorOld = Gizmos.color;
@@ -397,24 +397,31 @@ namespace Cinemachine.Editor
             for (float t = path.MinPos + step; t <= tEnd; t += step)
             {
                 Vector3 p = path.EvaluatePosition(t);
-                Quaternion q = path.EvaluateOrientation(t);
-                Vector3 w = (q * Vector3.right) * halfWidth;
-                Vector3 w2 = w * 1.2f;
-                Vector3 p0 = p - w2;
-                Vector3 p1 = p + w2;
-                Gizmos.DrawLine(p0, p1);
-                Gizmos.DrawLine(lastPos - lastW, p - w);
-                Gizmos.DrawLine(lastPos + lastW, p + w);
-
+                if (!isActive || halfWidth == 0)
+                {
+                    Gizmos.DrawLine(p, lastPos);
+                }
+                else
+                {
+                    Quaternion q = path.EvaluateOrientation(t);
+                    Vector3 w = (q * Vector3.right) * halfWidth;
+                    Vector3 w2 = w * 1.2f;
+                    Vector3 p0 = p - w2;
+                    Vector3 p1 = p + w2;
+                    Gizmos.DrawLine(p0, p1);
+                    Gizmos.DrawLine(lastPos - lastW, p - w);
+                    Gizmos.DrawLine(lastPos + lastW, p + w);
 #if false
-                // Show the normals, for debugging
-                Gizmos.color = Color.red;
-                Vector3 y = (q * Vector3.up) * halfWidth;
-                Gizmos.DrawLine(p, p + y);
-                Gizmos.color = pathColor;
+                    // Show the normals, for debugging
+                    Gizmos.color = Color.red;
+                    Vector3 y = (q * Vector3.up) * halfWidth;
+                    Gizmos.DrawLine(p, p + y);
+                    Gizmos.color = pathColor;
 #endif
+                    lastW = w;
+                }
+
                 lastPos = p;
-                lastW = w;
             }
             Gizmos.color = colorOld;
         }
@@ -423,9 +430,8 @@ namespace Cinemachine.Editor
              | GizmoType.InSelectionHierarchy | GizmoType.Pickable, typeof(CinemachinePath))]
         static void DrawGizmos(CinemachinePath path, GizmoType selectionType)
         {
-            DrawPathGizmo(path,
-                (Selection.activeGameObject == path.gameObject)
-                ? path.m_Appearance.pathColor : path.m_Appearance.inactivePathColor);
+            var isActive = Selection.activeGameObject == path.gameObject; 
+            DrawPathGizmo(path, isActive ? path.m_Appearance.pathColor : path.m_Appearance.inactivePathColor, isActive);
         }
     }
 }

--- a/Editor/Editors/CinemachineSmoothPathEditor.cs
+++ b/Editor/Editors/CinemachineSmoothPathEditor.cs
@@ -246,9 +246,9 @@ namespace Cinemachine.Editor
              | GizmoType.InSelectionHierarchy | GizmoType.Pickable, typeof(CinemachineSmoothPath))]
         static void DrawGizmos(CinemachineSmoothPath path, GizmoType selectionType)
         {
+            var isActive = Selection.activeGameObject == path.gameObject;
             CinemachinePathEditor.DrawPathGizmo(path,
-                (Selection.activeGameObject == path.gameObject)
-                ? path.m_Appearance.pathColor : path.m_Appearance.inactivePathColor);
+                isActive ? path.m_Appearance.pathColor : path.m_Appearance.inactivePathColor, isActive);
         }
     }
 }

--- a/Editor/Editors/CinemachineTrackedDollyEditor.cs
+++ b/Editor/Editors/CinemachineTrackedDollyEditor.cs
@@ -56,10 +56,11 @@ namespace Cinemachine.Editor
                 CinemachinePathBase path = target.m_Path;
                 if (path != null)
                 {
-                    CinemachinePathEditor.DrawPathGizmo(path, path.m_Appearance.pathColor);
+                    var isActive = CinemachineCore.Instance.IsLive(target.VirtualCamera);
+                    CinemachinePathEditor.DrawPathGizmo(path, path.m_Appearance.pathColor, isActive);
                     Vector3 pos = path.EvaluatePositionAtUnit(target.m_PathPosition, target.m_PositionUnits);
                     Color oldColor = Gizmos.color;
-                    Gizmos.color = CinemachineCore.Instance.IsLive(target.VirtualCamera)
+                    Gizmos.color = isActive
                         ? CinemachineSettings.CinemachineCoreSettings.ActiveGizmoColour
                         : CinemachineSettings.CinemachineCoreSettings.InactiveGizmoColour;
                     Gizmos.DrawLine(pos, target.VirtualCamera.State.RawPosition);

--- a/Runtime/Behaviours/CinemachineSmoothPath.cs
+++ b/Runtime/Behaviours/CinemachineSmoothPath.cs
@@ -160,7 +160,7 @@ namespace Cinemachine
         }
 
         /// <summary>Get a worldspace position of a point along the path</summary>
-        /// <param name="pos">Postion along the path.  Need not be normalized.</param>
+        /// <param name="pos">Position along the path.  Need not be normalized.</param>
         /// <returns>World-space position of the point along at path at pos</returns>
         public override Vector3 EvaluatePosition(float pos)
         {
@@ -181,7 +181,7 @@ namespace Cinemachine
         }
 
         /// <summary>Get the tangent of the curve at a point along the path.</summary>
-        /// <param name="pos">Postion along the path.  Need not be normalized.</param>
+        /// <param name="pos">Position along the path.  Need not be normalized.</param>
         /// <returns>World-space direction of the path tangent.
         /// Length of the vector represents the tangent strength</returns>
         public override Vector3 EvaluateTangent(float pos)
@@ -202,11 +202,13 @@ namespace Cinemachine
         }
 
         /// <summary>Get the orientation the curve at a point along the path.</summary>
-        /// <param name="pos">Postion along the path.  Need not be normalized.</param>
+        /// <param name="pos">Position along the path.  Need not be normalized.</param>
         /// <returns>World-space orientation of the path, as defined by tangent, up, and roll.</returns>
         public override Quaternion EvaluateOrientation(float pos)
         {
-            Quaternion result = transform.rotation;
+            Quaternion transformRot = transform.rotation;
+            Vector3 transformUp = transformRot * Vector3.up;
+            Quaternion result = transformRot;
             if (m_Waypoints.Length > 0)
             {
                 float roll = 0;
@@ -225,12 +227,23 @@ namespace Cinemachine
                 Vector3 fwd = EvaluateTangent(pos);
                 if (!fwd.AlmostZero())
                 {
-                    Vector3 up = transform.rotation * Vector3.up;
-                    Quaternion q = Quaternion.LookRotation(fwd, up);
-                    result = q * Quaternion.AngleAxis(roll, Vector3.forward);
+                    Quaternion q = Quaternion.LookRotation(fwd, transformUp);
+                    result = q * RollAroundForward(roll);
                 }
             }
             return result;
         }
+        
+        // same as Quaternion.AngleAxis(roll, Vector3.forward), just simplified
+        Quaternion RollAroundForward(float angle)
+        {
+            float halfAngle = angle * 0.5F * Mathf.Deg2Rad;
+            return new Quaternion(
+                0,
+                0,
+                Mathf.Sin(halfAngle),
+                Mathf.Cos(halfAngle));
+        }
+        
     }
 }

--- a/Runtime/Core/SplineHelpers.cs
+++ b/Runtime/Core/SplineHelpers.cs
@@ -17,7 +17,7 @@ namespace Cinemachine.Utility
             float t, Vector3 p0, Vector3 p1, Vector3 p2, Vector3 p3)
         {
             t = Mathf.Clamp01(t);
-            return (-3f * p0 + 9f * p1 - 9f * p2 + 3f * p3) * t * t
+            return (-3f * p0 + 9f * p1 - 9f * p2 + 3f * p3) * (t * t)
                 +  (6f * p0 - 12f * p1 + 6f * p2) * t
                 -  3f * p0 + 3f * p1;
         }


### PR DESCRIPTION
- Only render full "railroad" track for currently active selection,
- Small micro-optimizations in path evaluation code.

On BoatAttack project, cuts down CM path gizmo rendering time (per camera - there's two cameras in that project) from 4.06ms down to 0.79ms on my machine.