### PR TITLE
Dev/nested scrubbubble

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: CinemachineNewVirtualCamera.AddComponent() now works properly
 - Bugfix: removed compile errors when Physics2D module is disabled
 - Added Multi-object edit capabilities to virtual cameras and extensions 
+- Timeline Scrub Bubble now supports nested timelines, with some known limitations to be addressed with a future Tiemline package release
+- Added support for deterministic noise in the context of controlled rendering (via CinemachineCore.CurrentTimeOverride)
 
 ## [2.6.0] - 2020-06-04
 ### New Features and Bugfixes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: CinemachineNewVirtualCamera.AddComponent() now works properly
 - Bugfix: removed compile errors when Physics2D module is disabled
 - Added Multi-object edit capabilities to virtual cameras and extensions 
-- Timeline Scrub Bubble now supports nested timelines, with some known limitations to be addressed with a future Tiemline package release
+- Timeline Scrub Bubble now supports nested timelines, with some known limitations to be addressed with a future Timeline package release
 - Added support for deterministic noise in the context of controlled rendering (via CinemachineCore.CurrentTimeOverride)
 
 ## [2.6.0] - 2020-06-04

--- a/Editor/Timeline/CinemachineShotClipEditor.cs
+++ b/Editor/Timeline/CinemachineShotClipEditor.cs
@@ -17,13 +17,8 @@ public class CinemachineShotClipEditor : ClipEditor
     [InitializeOnLoad]
     class EditorInitialize 
     { 
-        static EditorInitialize() 
-        { 
-            CinemachineMixer.GetMasterPlayableDirector = GetMasterDirector; 
-            CinemachineMixer.GetInspectedPlayableDirector = GetInspectedDirector; 
-        } 
+        static EditorInitialize() { CinemachineMixer.GetMasterPlayableDirector = GetMasterDirector; } 
         static PlayableDirector GetMasterDirector() { return TimelineEditor.masterDirector; }
-        static PlayableDirector GetInspectedDirector() { return TimelineEditor.inspectedDirector; }
     }
 
     public override ClipDrawOptions GetClipOptions(TimelineClip clip)

--- a/Extras~/ReleaseNotes.txt
+++ b/Extras~/ReleaseNotes.txt
@@ -1,4 +1,5 @@
 <size=20><b>Version 2.6.1</b></size>
+
 - Bugfix: vertical group composition was not composing properly
 - Bugfix (1252431): Fixed unnecessary GC Memory allocation every frame when using timeline  
 - Bugfix: StateDrivenCamera was choosing parent state if only 1 clip in blendstate, even though there was a vcam assigned to that clip
@@ -8,8 +9,12 @@
 - Bugfix: CinemachineNewVirtualCamera.AddComponent() now works properly
 - Bugfix: removed compile errors when Physics2D module is disabled
 - Added Multi-object edit capabilities to virtual cameras and extensions 
+- Timeline Scrub Bubble now supports nested timelines, with some known limitations to be addressed with a future Tiemline package release
+- Added support for deterministic noise in the context of controlled rendering (via CinemachineCore.CurrentTimeOverride)
+
 
 <size=20><b>Version 2.6.0</b></size>
+
 - Added AxisState.IInputProvider API to better support custom input systems
 - Added CinemachineInpiutProvider behaviour to support Unity's new input system
 - Added Timeline Scrubbing cache: when enabled, simulates damping and noise when scrubbing in timeline
@@ -52,6 +57,7 @@
 
 
 <size=20><b>Version 2.5.0</b></size>
+
 - Accommodate simultaneous precesnce of HDRP and URP
 - Regression fix: Axis was always recentered in Edit mode, even if recentering is off
 

--- a/Extras~/ReleaseNotes.txt
+++ b/Extras~/ReleaseNotes.txt
@@ -9,7 +9,7 @@
 - Bugfix: CinemachineNewVirtualCamera.AddComponent() now works properly
 - Bugfix: removed compile errors when Physics2D module is disabled
 - Added Multi-object edit capabilities to virtual cameras and extensions 
-- Timeline Scrub Bubble now supports nested timelines, with some known limitations to be addressed with a future Tiemline package release
+- Timeline Scrub Bubble now supports nested timelines, with some known limitations to be addressed with a future Timeline package release
 - Added support for deterministic noise in the context of controlled rendering (via CinemachineCore.CurrentTimeOverride)
 
 

--- a/Runtime/Behaviours/CinemachineBlendListCamera.cs
+++ b/Runtime/Behaviours/CinemachineBlendListCamera.cs
@@ -155,7 +155,7 @@ namespace Cinemachine
         {
             base.OnTransitionFromCamera(fromCam, worldUp, deltaTime);
             InvokeOnTransitionInExtensions(fromCam, worldUp, deltaTime);
-            mActivationTime = Time.time;
+            mActivationTime = CinemachineCore.CurrentTime;
             mCurrentInstruction = 0;
             LiveChild = null;
             mActiveBlend = null;
@@ -339,7 +339,7 @@ namespace Cinemachine
                 return;
             }
 
-            float now = Time.time;
+            float now = CinemachineCore.CurrentTime;
             if (mCurrentInstruction < 0 || deltaTime < 0)
             {
                 mActivationTime = now;

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -186,7 +186,7 @@ namespace Cinemachine
             set
             {
                 if (value != null && !CinemachineCore.Instance.IsLive(value))
-                    value.OnTransitionFromCamera(null, Vector3.up, Time.deltaTime);
+                    value.OnTransitionFromCamera(null, Vector3.up, CinemachineCore.DeltaTime);
                 mSoloCamera = value;
             }
         }

--- a/Runtime/Behaviours/CinemachineClearShot.cs
+++ b/Runtime/Behaviours/CinemachineClearShot.cs
@@ -351,7 +351,7 @@ namespace Cinemachine
             }
             mRandomizeNow = false;
 
-            float now = Time.time;
+            float now = CinemachineCore.CurrentTime;
             if (mActivationTime != 0)
             {
                 // Is it active now?

--- a/Runtime/Behaviours/CinemachineCollider.cs
+++ b/Runtime/Behaviours/CinemachineCollider.cs
@@ -211,7 +211,7 @@ namespace Cinemachine
             {
                 if (m_SmoothedTime != 0 && smoothingTime > Epsilon)
                 {
-                    float now = Time.timeSinceLevelLoad;
+                    float now = CinemachineCore.CurrentTime;
                     if (now - m_SmoothedTime < smoothingTime)
                         return Mathf.Min(distance, m_SmoothedDistance);
                 }
@@ -219,7 +219,7 @@ namespace Cinemachine
             }
             public void UpdateDistanceSmoothing(float distance, float smoothingTime)
             {
-                float now = Time.timeSinceLevelLoad;
+                float now = CinemachineCore.CurrentTime;
                 if (m_SmoothedDistance == 0 || distance <= m_SmoothedDistance)
                 {
                     m_SmoothedDistance = distance;
@@ -228,7 +228,7 @@ namespace Cinemachine
             }
             public void ResetDistanceSmoothing(float smoothingTime)
             {
-                float now = Time.timeSinceLevelLoad;
+                float now = CinemachineCore.CurrentTime;
                 if (now - m_SmoothedTime >= smoothingTime)
                     m_SmoothedDistance = m_SmoothedTime = 0;
             }
@@ -281,7 +281,7 @@ namespace Cinemachine
                     displacement = PreserveLignOfSight(ref state, ref extra);
                     if (m_MinimumOcclusionTime > Epsilon)
                     {
-                        float now = Time.timeSinceLevelLoad;
+                        float now = CinemachineCore.CurrentTime;
                         if (displacement.sqrMagnitude < Epsilon)
                             extra.occlusionStartTime = 0;
                         else

--- a/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
+++ b/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
@@ -437,7 +437,7 @@ namespace Cinemachine
             while (hash != 0 && !mInstructionDictionary.ContainsKey(hash))
                 hash = mStateParentLookup.ContainsKey(hash) ? mStateParentLookup[hash] : 0;
 
-            float now = Time.time;
+            float now = CinemachineCore.CurrentTime;
             if (mActivationTime != 0)
             {
                 // Is it active now?

--- a/Runtime/Behaviours/CinemachineVirtualCamera.cs
+++ b/Runtime/Behaviours/CinemachineVirtualCamera.cs
@@ -133,6 +133,7 @@ namespace Cinemachine
         public override float GetMaxDampTime()
         {
             float maxDamp = base.GetMaxDampTime();
+            UpdateComponentPipeline();
             if (m_ComponentPipeline != null)
                 for (int i = 0; i < m_ComponentPipeline.Length; ++i)
                     maxDamp = Mathf.Max(maxDamp, m_ComponentPipeline[i].GetMaxDampTime());

--- a/Runtime/Components/CinemachineBasicMultiChannelPerlin.cs
+++ b/Runtime/Components/CinemachineBasicMultiChannelPerlin.cs
@@ -21,7 +21,8 @@ namespace Cinemachine
         /// <summary>
         /// Serialized property for referencing a NoiseSettings asset
         /// </summary>
-        [Tooltip("The asset containing the Noise Profile.  Define the frequencies and amplitudes there to make a characteristic noise profile.  Make your own or just use one of the many presets.")]
+        [Tooltip("The asset containing the Noise Profile.  Define the frequencies and amplitudes "
+            + "there to make a characteristic noise profile.  Make your own or just use one of the many presets.")]
         [FormerlySerializedAs("m_Definition")]
         [NoiseSettingsProperty]
         public NoiseSettings m_NoiseProfile;
@@ -35,13 +36,15 @@ namespace Cinemachine
         /// <summary>
         /// Gain to apply to the amplitudes defined in the settings asset.
         /// </summary>
-        [Tooltip("Gain to apply to the amplitudes defined in the NoiseSettings asset.  1 is normal.  Setting this to 0 completely mutes the noise.")]
+        [Tooltip("Gain to apply to the amplitudes defined in the NoiseSettings asset.  1 is normal.  "
+            + "Setting this to 0 completely mutes the noise.")]
         public float m_AmplitudeGain = 1f;
 
         /// <summary>
         /// Scale factor to apply to the frequencies defined in the settings asset.
         /// </summary>
-        [Tooltip("Scale factor to apply to the frequencies defined in the NoiseSettings asset.  1 is normal.  Larger magnitudes will make the noise shake more rapidly.")]
+        [Tooltip("Scale factor to apply to the frequencies defined in the NoiseSettings asset.  1 is normal.  "
+            + "Larger magnitudes will make the noise shake more rapidly.")]
         public float m_FrequencyGain = 1f;
 
         /// <summary>True if the component is valid, i.e. it has a noise definition and is enabled.</summary>
@@ -59,7 +62,10 @@ namespace Cinemachine
         public override void MutateCameraState(ref CameraState curState, float deltaTime)
         {
             if (!IsValid || deltaTime < 0)
+            {
+                mInitialized = false;
                 return;
+            }
 
             if (!mInitialized)
                 Initialize();
@@ -101,7 +107,7 @@ namespace Cinemachine
         void Initialize()
         {
             mInitialized = true;
-            mNoiseTime = 0;
+            mNoiseTime = CinemachineCore.CurrentTime * m_FrequencyGain;
             if (mNoiseOffsets == Vector3.zero)
                 ReSeed();
         }

--- a/Runtime/Core/AxisState.cs
+++ b/Runtime/Core/AxisState.cs
@@ -365,7 +365,7 @@ namespace Cinemachine
             /// <summary>Cancel any recenetering in progress.</summary>
             public void CancelRecentering()
             {
-                mLastAxisInputTime = Time.time;
+                mLastAxisInputTime = CinemachineCore.CurrentTime;
                 mRecenteringVelocity = 0;
             }
 
@@ -395,7 +395,7 @@ namespace Cinemachine
                 if (delta == 0)
                     return;
 
-                if (Time.time < (mLastAxisInputTime + m_WaitTime))
+                if (CinemachineCore.CurrentTime < (mLastAxisInputTime + m_WaitTime))
                     return;
 
                 // Determine the direction

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -70,6 +70,22 @@ namespace Cinemachine
         public static float UniformDeltaTimeOverride = -1;
 
         /// <summary>
+        /// Replacement for Time.deltaTime, taking UniformDeltaTimeOverride into account.
+        /// </summary>
+        public static float DeltaTime => UniformDeltaTimeOverride >= 0 ? UniformDeltaTimeOverride : Time.deltaTime;
+
+        /// <summary>
+        /// If non-negative, cinemachine willuse this value whenever it wants current game time.
+        /// Usage is for master timelines in manual update mode, for deterministic behaviour.
+        /// </summary>
+        public static float CurrentTimeOverride = -1;
+
+        /// <summary>
+        /// Replacement for Time.time, taking CurrentTimeTimeOverride into account.
+        /// </summary>
+        public static float CurrentTime => CurrentTimeOverride >= 0 ? CurrentTimeOverride : Time.time;
+
+        /// <summary>
         /// Delegate for overriding a blend that is about to be applied to a transition.
         /// A handler can either return the default blend, or a new blend specific to
         /// current conditions.
@@ -214,7 +230,7 @@ namespace Cinemachine
             CinemachineVirtualCameraBase currentRoundRobin = mRoundRobinVcamLastFrame;
 
             // Update the fixed frame count
-            float now = Time.time;
+            float now = CinemachineCore.CurrentTime;
             if (now != mLastUpdateTime)
             {
                 mLastUpdateTime = now;

--- a/Runtime/Core/Predictor.cs
+++ b/Runtime/Core/Predictor.cs
@@ -203,7 +203,7 @@ namespace Cinemachine.Utility
                 Item item = new Item();
                 item.velocity = velocity;
                 item.weight = weight;
-                item.time = Time.time;
+                item.time = CinemachineCore.CurrentTime;
                 if (mCount == FilterSize)
                     PopBottom();
                 ++mCount;
@@ -222,7 +222,7 @@ namespace Cinemachine.Utility
         {
             if (mCount > 0)
             {
-                float time = Time.time;
+                float time = CinemachineCore.CurrentTime;
                 Item item = mHistory[mBottom];
                 if (++mBottom == FilterSize)
                     mBottom = 0;
@@ -239,7 +239,7 @@ namespace Cinemachine.Utility
         /// <summary>Decay the history.  This should be called every frame.</summary>
         public void DecayHistory()
         {
-            float time = Time.time;
+            float time = CinemachineCore.CurrentTime;
             float decay = Decay(time - mWeightTime);
             mWeightSum *= decay;
             mWeightTime = time;

--- a/Runtime/Core/TargetPositionCache.cs
+++ b/Runtime/Core/TargetPositionCache.cs
@@ -17,6 +17,11 @@ namespace Cinemachine
         
         static Mode m_CacheMode = Mode.Disabled;
 
+#if UNITY_EDITOR
+        static TargetPositionCache() { UnityEngine.SceneManagement.SceneManager.sceneLoaded += OnSceneLoaded; }
+        static void OnSceneLoaded(UnityEngine.SceneManagement.Scene scene, UnityEngine.SceneManagement.LoadSceneMode mode) { ClearCache(); }
+#endif
+
         public static Mode CacheMode
         {
             get => m_CacheMode;

--- a/Runtime/Core/UpdateTracker.cs
+++ b/Runtime/Core/UpdateTracker.cs
@@ -121,7 +121,7 @@ namespace Cinemachine
         public static void OnUpdate(UpdateClock currentClock)
         {
             // Do something only if we are the first controller processing this frame
-            float now = Time.time;
+            float now = CinemachineCore.CurrentTime;
             if (now != mLastUpdateTime)
             {
                 mLastUpdateTime = now;

--- a/Runtime/Impulse/CinemachineImpulseManager.cs
+++ b/Runtime/Impulse/CinemachineImpulseManager.cs
@@ -386,7 +386,7 @@ namespace Cinemachine
         /// This is the Impulse system's current time.  
         /// Takes into accoount whether impulse is ignoring time scale.
         /// </summary>
-        public float CurrentTime { get { return IgnoreTimeScale ? Time.realtimeSinceStartup : Time.time; } }
+        public float CurrentTime { get { return IgnoreTimeScale ? Time.realtimeSinceStartup : CinemachineCore.CurrentTime; } }
 
         /// <summary>Get a new ImpulseEvent</summary>
         public ImpulseEvent NewImpulseEvent()

--- a/Runtime/Timeline/CinemachineMixer.cs
+++ b/Runtime/Timeline/CinemachineMixer.cs
@@ -69,9 +69,6 @@ using System.Collections.Generic;
             public void ScrubToHere(
                 double currentTime, TargetPositionCache.Mode cacheMode, CinemachineBrain brain)
             {
-                if (brain == null)
-                    return;
-
                 TargetPositionCache.CacheMode = cacheMode;
                 TargetPositionCache.CurrentTime = (float)currentTime;
                 if (cacheMode != TargetPositionCache.Mode.Playback)
@@ -79,7 +76,7 @@ using System.Collections.Generic;
 
                 float stepSize = TargetPositionCache.CacheStepSize;
 
-                var up = brain.DefaultWorldUp;
+                var up = (brain != null) ? brain.DefaultWorldUp : Vector3.up;
                 var endTime = TargetPositionCache.CurrentTime;
                 var startTime = Mathf.Max(
                     TargetPositionCache.CacheTimeRange.Start, endTime - GetMaxDampTime());
@@ -139,7 +136,7 @@ using System.Collections.Generic;
                 if (d != null && d.playableGraph.IsValid())
                     mPreviewPlay = GetMasterPlayableDirector().playableGraph.IsPlaying();
             }
-            if (Application.isPlaying || !TargetPositionCache.UseCache || GetMasterPlayableDirector == null)
+            if (Application.isPlaying || !TargetPositionCache.UseCache)
                 TargetPositionCache.CacheMode = TargetPositionCache.Mode.Disabled;
             else
             {

--- a/Runtime/Timeline/CinemachineMixer.cs
+++ b/Runtime/Timeline/CinemachineMixer.cs
@@ -16,7 +16,6 @@ using System.Collections.Generic;
         public delegate PlayableDirector MasterDirectorDelegate();
 
         static public MasterDirectorDelegate GetMasterPlayableDirector;
-        static public MasterDirectorDelegate GetInspectedPlayableDirector;
 
         // The brain that this track controls
         private CinemachineBrain mBrain;
@@ -140,25 +139,19 @@ using System.Collections.Generic;
                 if (d != null && d.playableGraph.IsValid())
                     mPreviewPlay = GetMasterPlayableDirector().playableGraph.IsPlaying();
             }
-            if (Application.isPlaying || !TargetPositionCache.UseCache)
+            if (Application.isPlaying || !TargetPositionCache.UseCache || GetMasterPlayableDirector == null)
                 TargetPositionCache.CacheMode = TargetPositionCache.Mode.Disabled;
             else
             {
-                // Use cache only if we are being inspected
-                var inspected = GetInspectedPlayableDirector != null ? GetInspectedPlayableDirector() : null;
-                if (GetInspectedPlayableDirector() == (PlayableDirector)playable.GetGraph().GetResolver())
+                if (m_ScrubbingCacheHelper == null)
                 {
-                    if (m_ScrubbingCacheHelper == null)
-                    {
-                        m_ScrubbingCacheHelper = new ScrubbingCacheHelper();
-                        m_ScrubbingCacheHelper.Init(playable);
-                    }
-                    var master = GetMasterPlayableDirector != null ? GetMasterPlayableDirector() : null;
-                    m_ScrubbingCacheHelper.ScrubToHere(
-                        master != null ? master.time : inspected.time, 
-                        mPreviewPlay ? TargetPositionCache.Mode.Record : TargetPositionCache.Mode.Playback,
-                        mBrain);
+                    m_ScrubbingCacheHelper = new ScrubbingCacheHelper();
+                    m_ScrubbingCacheHelper.Init(playable);
                 }
+                m_ScrubbingCacheHelper.ScrubToHere(
+                    GetMasterPlayableDirector().time, 
+                    mPreviewPlay ? TargetPositionCache.Mode.Record : TargetPositionCache.Mode.Playback,
+                    mBrain);
             }
 #else
             TargetPositionCache.CacheMode = TargetPositionCache.Mode.Disabled;

--- a/Samples~/Nested Timeline Scrub Bubble/.sample.json
+++ b/Samples~/Nested Timeline Scrub Bubble/.sample.json
@@ -1,0 +1,5 @@
+{
+    "displayName": "Scrub Bubble support for Nested Timelines (experimental)",
+    "interactiveImport": "false",
+    "description": "Experimental feature.  Adds a Timeline extension to support Scrubb Bubble for nested timelines.  This extension will become unnecessary when Timeline adds native support for the missing API"
+}

--- a/Samples~/Nested Timeline Scrub Bubble/CinemachineTimelineEditorExtensions.meta
+++ b/Samples~/Nested Timeline Scrub Bubble/CinemachineTimelineEditorExtensions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 42b594e637b21f94d82b1288bb2221a0
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/Nested Timeline Scrub Bubble/CinemachineTimelineEditorExtensions/CinemachineTimelineEditorExtensions.cs
+++ b/Samples~/Nested Timeline Scrub Bubble/CinemachineTimelineEditorExtensions/CinemachineTimelineEditorExtensions.cs
@@ -1,0 +1,16 @@
+using UnityEditor;
+
+/// <summary>
+/// This class installs the optional TimelineEditorExtension so that 
+/// Cinemachine's Timeline Scrub Bubble feature works fully with nested timelines.
+/// 
+/// In the future, this extension will be deprecated when Timeline adds the missing API natively
+/// </summary>
+[InitializeOnLoad]
+class CinemachineTimelineEditorExtensions 
+{
+    static CinemachineTimelineEditorExtensions() 
+    { 
+        CinemachineShotClipEditor.TimelineGlobalToLocalTime = TimelineEditorExtensions.ToLocalTime; 
+    } 
+}

--- a/Samples~/Nested Timeline Scrub Bubble/CinemachineTimelineEditorExtensions/CinemachineTimelineEditorExtensions.cs.meta
+++ b/Samples~/Nested Timeline Scrub Bubble/CinemachineTimelineEditorExtensions/CinemachineTimelineEditorExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93e93de8f3c3e8148909d9a8d56d4071
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/Nested Timeline Scrub Bubble/CinemachineTimelineEditorExtensions/TimelineEditorExtensions.meta
+++ b/Samples~/Nested Timeline Scrub Bubble/CinemachineTimelineEditorExtensions/TimelineEditorExtensions.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4e3d18aaecae68a41ab5dfc9d85a6785
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/Nested Timeline Scrub Bubble/CinemachineTimelineEditorExtensions/TimelineEditorExtensions/TimelineEditorExtensions.asmref
+++ b/Samples~/Nested Timeline Scrub Bubble/CinemachineTimelineEditorExtensions/TimelineEditorExtensions/TimelineEditorExtensions.asmref
@@ -1,0 +1,3 @@
+{
+    "reference": "GUID:02f771204943f4a40949438e873e3eff"
+}

--- a/Samples~/Nested Timeline Scrub Bubble/CinemachineTimelineEditorExtensions/TimelineEditorExtensions/TimelineEditorExtensions.asmref.meta
+++ b/Samples~/Nested Timeline Scrub Bubble/CinemachineTimelineEditorExtensions/TimelineEditorExtensions/TimelineEditorExtensions.asmref.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 7f4dd57b42c52514581c6e9d10e77165
+AssemblyDefinitionReferenceImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Samples~/Nested Timeline Scrub Bubble/CinemachineTimelineEditorExtensions/TimelineEditorExtensions/TimelineEditorExtensions.cs
+++ b/Samples~/Nested Timeline Scrub Bubble/CinemachineTimelineEditorExtensions/TimelineEditorExtensions/TimelineEditorExtensions.cs
@@ -1,0 +1,12 @@
+﻿using UnityEditor.Timeline;
+
+public class TimelineEditorExtensions 
+{
+    public static double ToLocalTime(double globalTime)
+    {
+        var window = TimelineEditor.window as TimelineWindow;
+        if (window == null)
+            return globalTime;
+        return window.state.editSequence.ToLocalTime(globalTime);
+    }
+}

--- a/Samples~/Nested Timeline Scrub Bubble/CinemachineTimelineEditorExtensions/TimelineEditorExtensions/TimelineEditorExtensions.cs.meta
+++ b/Samples~/Nested Timeline Scrub Bubble/CinemachineTimelineEditorExtensions/TimelineEditorExtensions/TimelineEditorExtensions.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f31c50c2f10fda845963e9f589a3c887
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,11 @@
             "displayName": "Cinemachine Example Scenes",
             "description": "Sample scenes illustrating various ways to use Cinemachine",
             "path": "Samples~/Cinemachine Example Scenes"
+        },
+        {
+            "displayName": "Scrub Bubble support for Nested Timelines (experimental)",
+            "description": "Experimental feature.  Adds a Timeline extension to support Scrubb Bubble for nested timelines.  This extension will become obsolete when Timeline adds native support for the missing API",
+            "path": "Samples~/Nested Timeline Scrub Bubble"
         }
     ]
 }


### PR DESCRIPTION
Disney issues.

1. Added support for nested timelines to scrub bubble.
2. Made noise deterministic (via values pushed to CinemachineCore.CurrentTimeOverride)

Item 1 requires an extension to the Timeline API.  Since they have a 1 year delay for new features, we're shipping a hack as Sample code, which needs to be installed to get full scrub bubble functionality for nested timelines.  If not installed, scrub bubble will work, but thee will be no visual indication on the clips in nested timelines.

Item 2 includes a change to AMB code.

Test project here: https://drive.google.com/file/d/1F47EqRWsVgmf5f9vBOZWuecZw-Ui2oLD/view?usp=sharing