### PR TITLE
Bugfix: BlendList camera was incorrectly holding 0-length camera cuts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix (1276391) - CM Brain Reset did not reset Custom Blends asset in inspector
 - Bugfix (1276343) - CM Brain inspector custom blends misaligned dropdown arrow
 - Bugfix (1256530) - disallow multiple components where appropriate
+- Bugfix: BlendList camera was incorrectly holding 0-length camera cuts
 
 
 ## [2.6.2] - 2020-09-02

--- a/Extras~/ReleaseNotes.txt
+++ b/Extras~/ReleaseNotes.txt
@@ -4,6 +4,7 @@
 - Bugfix (1276391) - CM Brain Reset did not reset Custom Blends asset in inspector
 - Bugfix (1276343) - CM Brain inspector custom blends misaligned dropdown arrow
 - Bugfix (1256530) - disallow multiple components where appropriate
+- Bugfix: BlendList camera was incorrectly holding 0-length camera cuts
 
 <size=20><b>Version 2.6.2</b></size>
 

--- a/Runtime/Behaviours/CinemachineBlendListCamera.cs
+++ b/Runtime/Behaviours/CinemachineBlendListCamera.cs
@@ -360,7 +360,7 @@ namespace Cinemachine
             }
 
             var holdTime = m_Instructions[mCurrentInstruction].m_Hold 
-                + m_Instructions[mCurrentInstruction].m_Blend.m_Time;
+                + m_Instructions[mCurrentInstruction].m_Blend.BlendTime;
             var minHold = mCurrentInstruction < m_Instructions.Length - 1 || m_Loop 
                 ? 0 : float.MaxValue;
             if (now - mActivationTime > Mathf.Max(minHold, holdTime))

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -628,7 +628,7 @@ namespace Cinemachine
                 {
                     // Create a blend (curve will be null if a cut)
                     var blendDef = LookupBlend(outGoingCamera, activeCamera);
-                    if (blendDef.BlendCurve != null && blendDef.m_Time > 0)
+                    if (blendDef.BlendCurve != null && blendDef.BlendTime > 0)
                     {
                         if (frame.blend.IsComplete)
                             frame.blend.CamA = outGoingCamera;  // new blend
@@ -638,7 +638,7 @@ namespace Cinemachine
                             // with the same blend in reverse, adjust the belnd time
                             if (frame.blend.CamA == activeCamera
                                 && frame.blend.CamB == outGoingCamera
-                                && frame.blend.Duration <= blendDef.m_Time)
+                                && frame.blend.Duration <= blendDef.BlendTime)
                             {
                                 blendDef.m_Time = frame.blend.TimeInBlend;
                             }
@@ -652,7 +652,7 @@ namespace Cinemachine
                         }
                     }
                     frame.blend.BlendCurve = blendDef.BlendCurve;
-                    frame.blend.Duration = blendDef.m_Time;
+                    frame.blend.Duration = blendDef.BlendTime;
                     frame.blend.TimeInBlend = 0;
                 }
                 // Set the current active camera

--- a/Runtime/Core/CinemachineBlend.cs
+++ b/Runtime/Core/CinemachineBlend.cs
@@ -174,9 +174,15 @@ namespace Cinemachine
         [Tooltip("Shape of the blend curve")]
         public Style m_Style;
 
-        /// <summary>The duration (in seconds) of the blend</summary>
+        /// <summary>The duration (in seconds) of the blend, if not a cut.  
+        /// If style is a cut, then this value is ignored.</summary>
         [Tooltip("Duration of the blend, in seconds")]
         public float m_Time;
+
+        /// <summary>
+        /// Get the duration of the blend, in seconds.  Will return 0 if blend style is a cut.
+        /// </summary>
+        public float BlendTime { get { return m_Style == Style.Cut ? 0 : m_Time; } }
 
         /// <summary>Constructor</summary>
         /// <param name="style">The shape of the blend curve.</param>

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -682,7 +682,7 @@ namespace Cinemachine
             CinemachineBlendDefinition blendDef,
             CinemachineBlend activeBlend)
         {
-            if (blendDef.BlendCurve == null || blendDef.m_Time <= 0 || (camA == null && camB == null))
+            if (blendDef.BlendCurve == null || blendDef.BlendTime <= 0 || (camA == null && camB == null))
                 return null;
             if (activeBlend != null)
             {
@@ -690,7 +690,7 @@ namespace Cinemachine
                 // with the same blend in reverse, adjust the belnd time
                 if (activeBlend.CamA == camB
                     && activeBlend.CamB == camA
-                    && activeBlend.Duration <= blendDef.m_Time)
+                    && activeBlend.Duration <= blendDef.BlendTime)
                 {
                     blendDef.m_Time = activeBlend.TimeInBlend;
                 }
@@ -699,7 +699,7 @@ namespace Cinemachine
             else if (camA == null)
                 camA = new StaticPointVirtualCamera(State, "(none)");
             return new CinemachineBlend(
-                camA, camB, blendDef.BlendCurve, blendDef.m_Time, 0);
+                camA, camB, blendDef.BlendCurve, blendDef.BlendTime, 0);
         }
 
         /// <summary>


### PR DESCRIPTION
Bugfix for issue reported here:
https://forum.unity.com/threads/unexpected-delay-in-blend-list-camera-cuts.970029/#post-6312258