### PR TITLE
Bugfix for 1174993 + release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix (1276343) - CM Brain inspector custom blends misaligned dropdown arrow
 - Bugfix (1256530) - disallow multiple components where appropriate
 - Bugfix: BlendList camera was incorrectly holding 0-length camera cuts
+- Bugfix (1174993) - CM Brain logo was not added to Hierarchy next to Main Camera after adding vcam for the first time after importing CM. 
 
 
 ## [2.6.2] - 2020-09-02

--- a/Editor/Windows/CinemachineSettings.cs
+++ b/Editor/Windows/CinemachineSettings.cs
@@ -237,10 +237,11 @@ namespace Cinemachine.Editor
         /// after adding a virtual camera to the project for the first time
         static void OnPackageLoadedInEditor()
         {
-            if (CinemachineLogoTexture == null) {
-				// After adding the CM to a project, we need to wait for one update cycle for the assets to load
+            if (CinemachineLogoTexture == null) 
+            {
+                // After adding the CM to a project, we need to wait for one update cycle for the assets to load
                 EditorApplication.update += OnPackageLoadedInEditor; 
-			}
+            }
             else
             {
                 EditorApplication.update -= OnPackageLoadedInEditor;

--- a/Editor/Windows/CinemachineSettings.cs
+++ b/Editor/Windows/CinemachineSettings.cs
@@ -232,6 +232,22 @@ namespace Cinemachine.Editor
 
         internal static event Action AdditionalCategories = null;
 
+        [InitializeOnLoadMethod]
+        /// Ensures that CM Brain logo is added to the Main Camera
+        /// after adding a virtual camera to the project for the first time
+        static void OnPackageLoadedInEditor()
+        {
+            if (CinemachineLogoTexture == null) {
+				// After adding the CM to a project, we need to wait for one update cycle for the assets to load
+                EditorApplication.update += OnPackageLoadedInEditor; 
+			}
+            else
+            {
+                EditorApplication.update -= OnPackageLoadedInEditor;
+                EditorApplication.hierarchyWindowItemOnGUI += OnHierarchyGUI; // Update hierarchy with CM Brain logo
+            }
+        }
+
         static CinemachineSettings()
         {
             if (CinemachineLogoTexture != null)

--- a/Extras~/ReleaseNotes.txt
+++ b/Extras~/ReleaseNotes.txt
@@ -5,6 +5,7 @@
 - Bugfix (1276343) - CM Brain inspector custom blends misaligned dropdown arrow
 - Bugfix (1256530) - disallow multiple components where appropriate
 - Bugfix: BlendList camera was incorrectly holding 0-length camera cuts
+- Bugfix (1174993) - CM Brain logo was not added to Hierarchy next to Main Camera after adding vcam for the first time after importing CM. 
 
 <size=20><b>Version 2.6.2</b></size>
 


### PR DESCRIPTION
Fix for https://fogbugz.unity3d.com/f/cases/1174993/.

The bug was caused by 
```
AssetDatabase.LoadAssetAtPath<Texture2D>( ScriptableObjectUtility.CinemachineRealativeInstallPath + "/Editor/EditorResources/cm_logo_sm.png"); 
```
Because AssetDatabase does not find the Texture after the package is added. We need to wait one update cycle.