### PR TITLE
Dev/confiner collider offset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix (1256530) - disallow multiple components where appropriate
 - Bugfix: BlendList camera was incorrectly holding 0-length camera cuts
 - Bugfix (1174993) - CM Brain logo was not added to Hierarchy next to Main Camera after adding vcam for the first time after importing CM. 
+- Bugfix (1100131) - Confiner is aware of 2D collider's offset attribute.
 
 
 ## [2.6.2] - 2020-09-02

--- a/Editor/Editors/CinemachineConfinerEditor.cs
+++ b/Editor/Editors/CinemachineConfinerEditor.cs
@@ -151,7 +151,7 @@ namespace Cinemachine.Editor
                     {
                         PolygonCollider2D poly = confiner.m_BoundingShape2D as PolygonCollider2D;
                         for (int i = 0; i < poly.pathCount; ++i)
-                            DrawPath(poly.GetPath(i), -1);
+                            DrawPath(poly.GetPath(i), -1, poly.offset);
                     }
                     else if (colliderType == typeof(CompositeCollider2D))
                     {
@@ -165,7 +165,7 @@ namespace Cinemachine.Editor
                             {
                                 path[j] *= revertCompositeColliderScale;
                             }
-                            DrawPath(path, numPoints);
+                            DrawPath(path, numPoints, poly.offset);
                         }
                     }
 #endif
@@ -177,7 +177,7 @@ namespace Cinemachine.Editor
             }
         }
 
-        static void DrawPath(Vector2[] path, int numPoints)
+        static void DrawPath(Vector2[] path, int numPoints, Vector2 offset)
         {
             if (numPoints < 0)
                 numPoints = path.Length;
@@ -187,7 +187,7 @@ namespace Cinemachine.Editor
                 for (int j = 0; j < numPoints; ++j)
                 {
                     Vector2 v = path[j];
-                    Gizmos.DrawLine(v0, v);
+                    Gizmos.DrawLine(v0 + offset, v + offset);
                     v0 = v;
                 }
             }

--- a/Extras~/ReleaseNotes.txt
+++ b/Extras~/ReleaseNotes.txt
@@ -6,6 +6,8 @@
 - Bugfix (1256530) - disallow multiple components where appropriate
 - Bugfix: BlendList camera was incorrectly holding 0-length camera cuts
 - Bugfix (1174993) - CM Brain logo was not added to Hierarchy next to Main Camera after adding vcam for the first time after importing CM. 
+- Bugfix (1100131) - Confiner is aware of 2D collider's offset attribute.
+
 
 <size=20><b>Version 2.6.2</b></size>
 

--- a/Runtime/Behaviours/CinemachineConfiner.cs
+++ b/Runtime/Behaviours/CinemachineConfiner.cs
@@ -255,10 +255,12 @@ namespace Cinemachine
                 int numPoints = m_pathCache[i].Count;
                 if (numPoints > 0)
                 {
-                    Vector2 v0 = m_BoundingShape2D.transform.TransformPoint(m_pathCache[i][numPoints - 1]);
+                    Vector2 v0 = m_BoundingShape2D.transform.TransformPoint(m_pathCache[i][numPoints - 1] 
+                                                                            + m_BoundingShape2D.offset);
                     for (int j = 0; j < numPoints; ++j)
                     {
-                        Vector2 v = m_BoundingShape2D.transform.TransformPoint(m_pathCache[i][j]);
+                        Vector2 v = m_BoundingShape2D.transform.TransformPoint(m_pathCache[i][j] 
+                                                                               + m_BoundingShape2D.offset);
                         Vector2 c = Vector2.Lerp(v0, v, p.ClosestPointOnSegment(v0, v));
                         float d = Vector2.SqrMagnitude(p - c);
                         if (d < bestDistance)


### PR DESCRIPTION
Bugfix for https://fogbugz.unity3d.com/f/cases/1100131/

2D colliders have a property called offset. Confiner was not taking it into consideration.