### PR TITLE
Dev/tooltips in property drawers

### DIFF
--- a/Editor/PropertyDrawers/AxisStatePropertyDrawer.cs
+++ b/Editor/PropertyDrawers/AxisStatePropertyDrawer.cs
@@ -15,7 +15,7 @@ namespace Cinemachine.Editor
         {
             float height = EditorGUIUtility.singleLineHeight;
             rect.height = height;
-            mExpanded = EditorGUI.Foldout(rect, mExpanded, label, true);
+            mExpanded = EditorGUI.Foldout(rect, mExpanded, EditorGUI.BeginProperty(rect, label, property), true);
             if (mExpanded)
             {
                 ++EditorGUI.indentLevel;

--- a/Editor/PropertyDrawers/CinemachineBlendDefinitionPropertyDrawer.cs
+++ b/Editor/PropertyDrawers/CinemachineBlendDefinitionPropertyDrawer.cs
@@ -16,7 +16,7 @@ namespace Cinemachine.Editor
             GUIContent timeText = new GUIContent(" s", timeProp.tooltip);
             var textDimensions = GUI.skin.label.CalcSize(timeText);
 
-            rect = EditorGUI.PrefixLabel(rect, label);
+            rect = EditorGUI.PrefixLabel(rect, EditorGUI.BeginProperty(rect, label, property));
 
             rect.y += vSpace; rect.height = EditorGUIUtility.singleLineHeight;
             rect.width -= floatFieldWidth + textDimensions.x;

--- a/Editor/PropertyDrawers/CinemachineTagFieldPropertyDrawer.cs
+++ b/Editor/PropertyDrawers/CinemachineTagFieldPropertyDrawer.cs
@@ -19,7 +19,7 @@ namespace Cinemachine.Editor
             tagValue = property.stringValue;
             EditorGUI.showMixedValue = property.hasMultipleDifferentValues;
             EditorGUI.BeginChangeCheck();
-            tagValue = EditorGUI.TagField(rect, label, tagValue);
+            tagValue = EditorGUI.TagField(rect, EditorGUI.BeginProperty(rect, label, property), tagValue);
             if (EditorGUI.EndChangeCheck())
                 property.stringValue = tagValue;
             EditorGUI.showMixedValue = false;

--- a/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
+++ b/Editor/PropertyDrawers/LensSettingsPropertyDrawer.cs
@@ -38,7 +38,7 @@ namespace Cinemachine.Editor
             rect.height = height;
             property.isExpanded = EditorGUI.Foldout(
                 new Rect(rect.x, rect.y, EditorGUIUtility.labelWidth, rect.height),
-                property.isExpanded, label, true);
+                property.isExpanded, EditorGUI.BeginProperty(rect, label, property), true);
             if (property.isExpanded)
             {
                 ++EditorGUI.indentLevel;

--- a/Editor/PropertyDrawers/NoiseSettingsPropertyDrawer.cs
+++ b/Editor/PropertyDrawers/NoiseSettingsPropertyDrawer.cs
@@ -15,7 +15,7 @@ namespace Cinemachine.Editor
             rect.width -= iconSize;
             int preset = sNoisePresets.IndexOf((NoiseSettings)property.objectReferenceValue);
             EditorGUI.showMixedValue = property.hasMultipleDifferentValues;
-            preset = EditorGUI.Popup(rect, label, preset, sNoisePresetNames);
+            preset = EditorGUI.Popup(rect, EditorGUI.BeginProperty(rect, label, property), preset, sNoisePresetNames);
             EditorGUI.showMixedValue = false;
             string labelText = label.text;
             NoiseSettings newProfile = preset < 0 ? null : sNoisePresets[preset] as NoiseSettings;

--- a/Editor/PropertyDrawers/OrbitalTransposerHeadingPropertyDrawer.cs
+++ b/Editor/PropertyDrawers/OrbitalTransposerHeadingPropertyDrawer.cs
@@ -14,7 +14,7 @@ namespace Cinemachine.Editor
         {
             float height = EditorGUIUtility.singleLineHeight;
             rect.height = height;
-            mExpanded = EditorGUI.Foldout(rect, mExpanded, label, true);
+            mExpanded = EditorGUI.Foldout(rect, mExpanded, EditorGUI.BeginProperty(rect, label, property), true);
             if (mExpanded)
             {
                 ++EditorGUI.indentLevel;

--- a/Editor/PropertyDrawers/VcamTargetPropertyDrawer.cs
+++ b/Editor/PropertyDrawers/VcamTargetPropertyDrawer.cs
@@ -12,7 +12,7 @@ namespace Cinemachine.Editor
             const float hSpace = 2;
             float iconSize = rect.height + 4;
             rect.width -= iconSize + hSpace;
-            EditorGUI.PropertyField(rect, property, label);
+            EditorGUI.PropertyField(rect, property, EditorGUI.BeginProperty(rect, label, property));
             rect.x += rect.width + hSpace; rect.width = iconSize;
 
             var oldEnabled = GUI.enabled;


### PR DESCRIPTION
fix for https://fogbugz.unity3d.com/f/cases/1285256/
tooltips were not being drawn by the CM custom property drawers.
A mystery until I found this: https://answers.unity.com/questions/1318754/propertydrawer-empty-tooltips.html