### PR TITLE
Moved Storyboard Global Mute to preferences

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix (1283984) - Error message when loading new scene with DontDestroyOnLoad
 - bugfix (1284701) - Edge-case exception when vcam is deleted
 - UI update - Moved Cinemachine menu to GameObject Create menu and Right Click context menu for Hierachy window.
+- Storyboard Global Mute moved from Cinemachine menu to Cinemachine preferences.
 
 
 ## [2.6.3] - 2020-09-16

--- a/Editor/Editors/CinemachineStoryboardEditor.cs
+++ b/Editor/Editors/CinemachineStoryboardEditor.cs
@@ -11,22 +11,9 @@ namespace Cinemachine.Editor
     [InitializeOnLoad]
     internal class CinemachineStoryboardMute
     {
-        const string StoryboardGlobalMuteMenuName = "Cinemachine/Storyboard Global Mute";
-        [MenuItem(StoryboardGlobalMuteMenuName, false)]
-        public static void StoryboardGlobalMute()
-        {
-            bool enable = !CinemachineStoryboardMute.Enabled;
-            CinemachineStoryboardMute.Enabled = enable;
-        }
-
         static CinemachineStoryboardMute()
         {
             CinemachineStoryboard.s_StoryboardGlobalMute = Enabled;
-
-             /// Delaying until first editor tick so that the menu
-             /// will be populated before setting check state, and
-             /// re-apply correct action
-             EditorApplication.delayCall += () => { UnityEditor.Menu.SetChecked(StoryboardGlobalMuteMenuName, Enabled); };
         }
 
         public static string kEnabledKey = "StoryboardMute_Enabled";
@@ -39,8 +26,6 @@ namespace Cinemachine.Editor
                 {
                     EditorPrefs.SetBool(kEnabledKey, value);
                     CinemachineStoryboard.s_StoryboardGlobalMute = value;
-                    UnityEditor.Menu.SetChecked(StoryboardGlobalMuteMenuName, value);
-
                     InspectorUtility.RepaintGameView();
                 }
             }

--- a/Editor/Windows/CinemachineSettings.cs
+++ b/Editor/Windows/CinemachineSettings.cs
@@ -300,6 +300,11 @@ namespace Cinemachine.Editor
                 GUILayout.EndScrollView();
             }
 
+            // Storyboard global mute
+            CinemachineStoryboardMute.Enabled = EditorGUILayout.Toggle(
+                new GUIContent("Storyboard Global Mute", "If checked, all storyboards are globally muted."), 
+                CinemachineStoryboardMute.Enabled);
+
             sScrollPosition = GUILayout.BeginScrollView(sScrollPosition);
 
             //CinemachineCore.sShowHiddenObjects


### PR DESCRIPTION
Move global mute option to preferences as first entry. Removed Cinemachine top menu.
Storyboard component has access to global mute too.

CMCL-162