### PR TITLE
Cleanup matrix code

### DIFF
--- a/Runtime/Core/UnityVectorExtensions.cs
+++ b/Runtime/Core/UnityVectorExtensions.cs
@@ -73,16 +73,6 @@ namespace Cinemachine.Utility
             return (vector - Vector3.Dot(vector, planeNormal) * planeNormal);
         }
         
-        
-        public static Vector3 ApplyTransformation(in Vector3 point, 
-            in Vector3 scale, in Quaternion rotation, in Vector3 translation)
-        {
-            var transformedPoint = new Vector3(point.x * scale.x, point.y * scale.y, point.z * scale.z);
-            transformedPoint = rotation * transformedPoint;
-            transformedPoint += translation;
-            return transformedPoint;
-        }
-        
         /// <summary>
         /// Calculates the intersection point defined by line_1 (p1, p2), and line_2 (p3, p4).
         /// Returns intersection type (0 = no intersection, 1 = lines intersect, 2 = segments intersect).


### PR DESCRIPTION
- Confiner is baked using its current transform - translation included.
- A delta matrix is computed to account for confiner offset and transform changes since baking.
- ConfinePoint() returns the confined point, not the displacement vector.  This is important because it has to be transformed back to world space **before** the displacement is calculated.
- Gizmo drawer sets Gizmos.matrix before drawing.  This is much more efficient than matrix-multiplying every point.
