### PR TITLE
make sure newly activated vcams don't get a huge frame delta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - bugfix (1284701) - Edge-case exception when vcam is deleted
 - UI update - Moved Cinemachine menu to GameObject Create menu and Right Click context menu for Hierachy window.
 - Storyboard Global Mute moved from Cinemachine menu to Cinemachine preferences.
+- Bugfix - long-idle vcams when reawakened sometimes had a single frame with a huge deltaTime
 
 
 ## [2.6.3] - 2020-09-16

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -323,10 +323,15 @@ namespace Cinemachine
             // Have we already been updated this frame?
             if (mUpdateStatus == null)
                 mUpdateStatus = new Dictionary<CinemachineVirtualCameraBase, UpdateStatus>();
-            UpdateStatus status;
-            if (!mUpdateStatus.TryGetValue(vcam, out status))
+            if (!mUpdateStatus.TryGetValue(vcam, out UpdateStatus status))
             {
-                status = new UpdateStatus();
+                status = new UpdateStatus
+                {
+                    lastUpdateFixedFrame = 0,
+                    lastUpdateMode = UpdateTracker.UpdateClock.Late,
+                    lastUpdateFrame = Time.frameCount + 2, // so that frameDelta ends up negative
+                    lastUpdateDeltaTime = FixedFrameCount + 2
+                };
                 mUpdateStatus.Add(vcam, status);
             }
             int frameDelta = (updateClock == UpdateTracker.UpdateClock.Late)
@@ -355,13 +360,6 @@ namespace Cinemachine
             public int lastUpdateFixedFrame;
             public UpdateTracker.UpdateClock lastUpdateMode;
             public float lastUpdateDeltaTime;
-            public UpdateStatus()
-            {
-                lastUpdateFrame = -2;
-                lastUpdateFixedFrame = 0;
-                lastUpdateMode = UpdateTracker.UpdateClock.Late;
-                lastUpdateDeltaTime = -2;
-            }
         }
         Dictionary<CinemachineVirtualCameraBase, UpdateStatus> mUpdateStatus;
 

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -327,10 +327,10 @@ namespace Cinemachine
             {
                 status = new UpdateStatus
                 {
-                    lastUpdateFixedFrame = 0,
+                    lastUpdateDeltaTime = -2,
                     lastUpdateMode = UpdateTracker.UpdateClock.Late,
                     lastUpdateFrame = Time.frameCount + 2, // so that frameDelta ends up negative
-                    lastUpdateDeltaTime = FixedFrameCount + 2
+                    lastUpdateFixedFrame = FixedFrameCount + 2
                 };
                 mUpdateStatus.Add(vcam, status);
             }


### PR DESCRIPTION
Bug reported here:
https://forum.unity.com/threads/mathf-perlinnoise-breaks-when-reactivating-vcams-too-often-for-too-long.999729/