### PR TITLE
Fix FindIntersection to handle parallel segments

### DIFF
--- a/Runtime/Behaviours/CinemachineConfiner2D.cs
+++ b/Runtime/Behaviours/CinemachineConfiner2D.cs
@@ -270,9 +270,8 @@ namespace Cinemachine
                 {
                     Vector2 p1 = polygon[index];
                     Vector2 p2 = polygon[(index + 1) % polygon.Count];
-                    int intersectionType = UnityVectorExtensions.FindIntersection(p, camRayEndFromCamPos2D, p1, p2, 
-                        out var intersection);
-                    if (intersectionType == 2 && (intersection - p2).sqrMagnitude < 0.01f)
+                    if (UnityVectorExtensions.FindIntersection(
+                        p, camRayEndFromCamPos2D, p1, p2, out _) == 2)
                     {
                         intersectionCount++;
                     }

--- a/Runtime/Behaviours/CinemachineConfiner2D.cs
+++ b/Runtime/Behaviours/CinemachineConfiner2D.cs
@@ -271,8 +271,8 @@ namespace Cinemachine
                     Vector2 p1 = polygon[index];
                     Vector2 p2 = polygon[(index + 1) % polygon.Count];
                     int intersectionType = UnityVectorExtensions.FindIntersection(p, camRayEndFromCamPos2D, p1, p2, 
-                        out _);
-                    if (intersectionType == 2)
+                        out var intersection);
+                    if (intersectionType == 2 && (intersection - p2).sqrMagnitude < 0.01f)
                     {
                         intersectionCount++;
                     }
@@ -288,8 +288,9 @@ namespace Cinemachine
             {
                 for (int i = 0; i < originalPath.Count; ++i)
                 {
-                    if (UnityVectorExtensions.FindIntersection(l1, l2, originalPath[i], 
-                        originalPath[(i + 1) % originalPath.Count], out _) == 2)
+                    var p4 = originalPath[(i + 1) % originalPath.Count];
+                    if (UnityVectorExtensions.FindIntersection(l1, l2, originalPath[i], p4, 
+                        out var intersection) == 2 && (intersection - p4).sqrMagnitude < 0.01f)
                     {
                         return true;
                     }

--- a/Runtime/Core/ShrinkablePolygon.cs
+++ b/Runtime/Core/ShrinkablePolygon.cs
@@ -469,10 +469,10 @@ namespace Cinemachine
                     for (int i = 0; i < m_Points.Count; ++i)
                     {
                         var mPoint = m_Points[i];
-                        
+
                         Vector2 direction = center - mPoint.m_Position;
                         mPoint.m_ShrinkDirection = direction.SquareNormalize();
-                        
+
                         m_Points[i] = mPoint;
                     }
                 }
@@ -685,13 +685,13 @@ namespace Cinemachine
                         shrinkablePolygon.m_Points[j].m_Position, shrinkablePolygon.m_Points[nextJ].m_Position,
                         out Vector2 intersection);
 
-                    if (intersectionType == 2 && intersection.sqrMagnitude >= Vector2.positiveInfinity.sqrMagnitude)
+                    if (intersectionType > 2)
                     {
                         // parallel lines so no need to divide.
                         shrinkablePolygon.m_State += k_NonLerpableStateChangePenalty;
                         return true; // subPolygons has nice intersections
                     }
-                    if (intersectionType == 2) // so we divide g into g1 and g2.
+                    if (intersectionType == 2 && (intersection - shrinkablePolygon.m_Points[nextJ].m_Position).sqrMagnitude < 0.01f) // so we divide g into g1 and g2.
                     {
                         var g1 = new ShrinkablePolygon();
                         {

--- a/Tests/Runtime/UnityVectorExtensionTests.cs
+++ b/Tests/Runtime/UnityVectorExtensionTests.cs
@@ -8,7 +8,7 @@ using Assert = UnityEngine.Assertions.Assert;
 public class UnityVectorExtensionTests
 {
     [Test]
-	    public void FindIntersectionTests()
+	public void FindIntersectionTests()
     {
         {
             var l1_p1 = new Vector2(0, 1);
@@ -18,8 +18,7 @@ public class UnityVectorExtensionTests
             int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
                 out Vector2 intersection);
             Assert.IsTrue(intersectionType == 2);
-            Assert.IsTrue(Mathf.Abs(intersection.x) < 1e-8f &&
-                          Mathf.Abs(intersection.y) < 1e-8f); // intersection should be Vector2.zero
+            Assert.IsTrue(AreApproximatelyEqual(intersection, Vector2.zero));
         }
         {
             var l1_p1 = new Vector2(0, 1);
@@ -29,8 +28,7 @@ public class UnityVectorExtensionTests
             int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
                 out Vector2 intersection);
             Assert.IsTrue(intersectionType == 2);
-            Assert.IsTrue(Mathf.Abs(intersection.x) < 1e-8f &&
-                          Mathf.Abs(intersection.y) < 1e-8f); // intersection should be Vector2.zero
+            Assert.IsTrue(AreApproximatelyEqual(intersection, Vector2.zero));
         }
         {
             var l1_p1 = new Vector2(0, 2);
@@ -40,8 +38,7 @@ public class UnityVectorExtensionTests
             int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
                 out Vector2 intersection);
             Assert.IsTrue(intersectionType == 1);
-            Assert.IsTrue(Mathf.Abs(intersection.x) < 1e-8f &&
-                          Mathf.Abs(intersection.y) < 1e-8f); // intersection should be Vector2.zero
+            Assert.IsTrue(AreApproximatelyEqual(intersection, Vector2.zero));
         }
         {
             var l1_p1 = new Vector2(0, 2);
@@ -51,6 +48,47 @@ public class UnityVectorExtensionTests
             int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
                 out Vector2 intersection);
             Assert.IsTrue(intersectionType == 0);
+            Assert.IsTrue(float.IsInfinity(intersection.x) && float.IsInfinity(intersection.y));
+        }
+        {
+            var l1_p1 = new Vector2(1, 2);
+            var l1_p2 = new Vector2(1, 1);
+            var l2_p1 = new Vector2(1, -2);
+            var l2_p2 = new Vector2(1, -1);
+            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
+                out Vector2 intersection);
+            Assert.IsTrue(intersectionType == 3);
+            Assert.IsTrue(float.IsInfinity(intersection.x) && float.IsInfinity(intersection.y));
+        }
+        {
+            var l1_p1 = new Vector2(1, 2);
+            var l1_p2 = new Vector2(1, -2);
+            var l2_p1 = new Vector2(1, 3);
+            var l2_p2 = new Vector2(1, 1);
+            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
+                out Vector2 intersection);
+            Assert.IsTrue(intersectionType == 4);
+            Assert.IsTrue(float.IsInfinity(intersection.x) && float.IsInfinity(intersection.y));
+        }
+        {
+            var l1_p1 = new Vector2(1, 2);
+            var l1_p2 = new Vector2(1, -2);
+            var l2_p1 = new Vector2(1, 2);
+            var l2_p2 = new Vector2(1, -2);
+            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
+                out Vector2 intersection);
+            Assert.IsTrue(intersectionType == 4);
+            Assert.IsTrue(float.IsInfinity(intersection.x) && float.IsInfinity(intersection.y));
+        }
+        {
+            var l1_p1 = new Vector2(1, 2);
+            var l1_p2 = new Vector2(1, -2);
+            var l2_p1 = new Vector2(1, -2);
+            var l2_p2 = new Vector2(1, 2);
+            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
+                out Vector2 intersection);
+            Assert.IsTrue(intersectionType == 4);
+            Assert.IsTrue(float.IsInfinity(intersection.x) && float.IsInfinity(intersection.y));
         }
         {
             var l1_p1 = new Vector2(0, 1);
@@ -59,7 +97,8 @@ public class UnityVectorExtensionTests
             var l2_p2 = new Vector2(1, 0);
             int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
                 out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 0);
+            Assert.IsTrue(intersectionType == 4);
+            Assert.IsTrue(float.IsInfinity(intersection.x) && float.IsInfinity(intersection.y));
         }
         {
             var l1_p1 = new Vector2(0, 0);
@@ -68,8 +107,8 @@ public class UnityVectorExtensionTests
             var l2_p2 = new Vector2(1, 0);
             int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
                 out Vector2 intersection);
-            Assert.IsTrue(intersectionType == 1);
-            Assert.IsTrue(intersection == l2_p2);
+            Assert.IsTrue(intersectionType == 2);
+            Assert.IsTrue(AreApproximatelyEqual(intersection, l2_p2));
         }
         {
             var l1_p1 = new Vector2(0, 0);
@@ -79,12 +118,59 @@ public class UnityVectorExtensionTests
             int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
                 out Vector2 intersection);
             Assert.IsTrue(intersectionType == 2);
-            Assert.IsTrue(intersection == l2_p1);
+            Assert.IsTrue(AreApproximatelyEqual(intersection, l2_p1));
+        }
+
+        // Parallel segments touching at one point
+        {
+            var l1_p1 = new Vector2(0, 3);
+            var l1_p2 = new Vector2(0, 5);
+            var l2_p1 = new Vector2(0, 5);
+            var l2_p2 = new Vector2(0, 9);
+            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
+                out Vector2 intersection);
+            Assert.IsTrue(intersectionType == 4);
+            Assert.IsTrue(AreApproximatelyEqual(intersection, l2_p1));
+        }
+        {
+            var l1_p1 = new Vector2(0, 5);
+            var l1_p2 = new Vector2(0, 3);
+            var l2_p1 = new Vector2(0, 5);
+            var l2_p2 = new Vector2(0, 9);
+            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
+                out Vector2 intersection);
+            Assert.IsTrue(intersectionType == 4);
+            Assert.IsTrue(AreApproximatelyEqual(intersection, l2_p1));
+        }
+        {
+            var l1_p1 = new Vector2(0, 3);
+            var l1_p2 = new Vector2(0, 5);
+            var l2_p1 = new Vector2(0, 9);
+            var l2_p2 = new Vector2(0, 5);
+            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
+                out Vector2 intersection);
+            Assert.IsTrue(intersectionType == 4);
+            Assert.IsTrue(AreApproximatelyEqual(intersection, l2_p2));
+        }
+        {
+            var l1_p1 = new Vector2(0, 5);
+            var l1_p2 = new Vector2(0, 3);
+            var l2_p1 = new Vector2(0, 9);
+            var l2_p2 = new Vector2(0, 5);
+            int intersectionType = UnityVectorExtensions.FindIntersection(l1_p1, l1_p2, l2_p1, l2_p2, 
+                out Vector2 intersection);
+            Assert.IsTrue(intersectionType == 4);
+            Assert.IsTrue(AreApproximatelyEqual(intersection, l2_p2));
         }
     }
-        
+
+    static bool AreApproximatelyEqual(Vector2 v1, Vector2 v2)
+    {
+        return Mathf.Abs(v2.x - v1.x) < 1e-5f && Mathf.Abs(v2.y - v1.y) < 1e-5f;
+    }
+
     [Test]
-     public void TestAngle()
+    public void TestAngle()
     {
         {
             Vector3 v1 = Vector3.up;


### PR DESCRIPTION
Fixed FindIntersection to handle overlapping and zero-length segments.
After implementing this, I noticed that a confiner unity test is failing. It's possible that the old behaviour of FindIntersection was hiding a bug.