### PR TITLE
Dev/bugfix 1272146

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Storyboard Global Mute moved from Cinemachine menu to Cinemachine preferences.
 - Bugfix - long-idle vcams when reawakened sometimes had a single frame with a huge deltaTime
 - Bugfix - PostProcessing temporarily stopped being applied after exiting play mode
+- Bugfix (1272146) - Adding vcam to a prefab asset no longer causes errors in console
 
 
 ## [2.6.3] - 2020-09-16

--- a/Editor/Editors/CinemachineVirtualCameraEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraEditor.cs
@@ -252,7 +252,8 @@ namespace Cinemachine.Editor
                         // Create a new pipeline
                         GameObject go =  InspectorUtility.CreateGameObject(name);
                         Undo.RegisterCreatedObjectUndo(go, "created pipeline");
-                        Undo.SetTransformParent(go.transform, vcam.transform, "parenting pipeline");
+                        if (PrefabUtility.GetPrefabInstanceStatus(vcam.gameObject) == PrefabInstanceStatus.NotAPrefab)
+                            Undo.SetTransformParent(go.transform, vcam.transform, "parenting pipeline");
                         Undo.AddComponent<CinemachinePipeline>(go);
 
                         // If copying, transfer the components

--- a/Editor/Editors/CinemachineVirtualCameraEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraEditor.cs
@@ -252,8 +252,8 @@ namespace Cinemachine.Editor
                         // Create a new pipeline
                         GameObject go =  InspectorUtility.CreateGameObject(name);
                         Undo.RegisterCreatedObjectUndo(go, "created pipeline");
-                        bool isPrefabOriginal = PrefabUtility.GetPrefabParent(vcam.gameObject) == null && PrefabUtility.GetPrefabObject(vcam.gameObject.transform) != null;
-                        if (!isPrefabOriginal)
+                        bool partOfPrefab = PrefabUtility.IsPartOfAnyPrefab(vcam.gameObject);
+                        if (!partOfPrefab)
                             Undo.SetTransformParent(go.transform, vcam.transform, "parenting pipeline");
                         Undo.AddComponent<CinemachinePipeline>(go);
 

--- a/Editor/Editors/CinemachineVirtualCameraEditor.cs
+++ b/Editor/Editors/CinemachineVirtualCameraEditor.cs
@@ -252,7 +252,8 @@ namespace Cinemachine.Editor
                         // Create a new pipeline
                         GameObject go =  InspectorUtility.CreateGameObject(name);
                         Undo.RegisterCreatedObjectUndo(go, "created pipeline");
-                        if (PrefabUtility.GetPrefabInstanceStatus(vcam.gameObject) == PrefabInstanceStatus.NotAPrefab)
+                        bool isPrefabOriginal = PrefabUtility.GetPrefabParent(vcam.gameObject) == null && PrefabUtility.GetPrefabObject(vcam.gameObject.transform) != null;
+                        if (!isPrefabOriginal)
                             Undo.SetTransformParent(go.transform, vcam.transform, "parenting pipeline");
                         Undo.AddComponent<CinemachinePipeline>(go);
 


### PR DESCRIPTION

Bugfix for https://fogbugz.unity3d.com/f/cases/resolve/1272146/

Error might happen at:
`Undo.SetTransformParent(go.transform, vcam.transform, "parenting pipeline");`
in CinemachineVirtualCameraEditor.cs.


Note, I tried the following ways to retrieve whether gameobject is prefab, but only isPrefabOriginal returns it correctly, even though the function it uses is marked as obsolete.
`var prefabInstance = PrefabUtility.GetPrefabInstanceStatus(vcam.gameObject); // says NotPrefab

                        bool isPrefabInstance = PrefabUtility.GetPrefabParent(vcam.gameObject) != null && PrefabUtility.GetPrefabObject(vcam.gameObject.transform) != null;

                        bool isPrefabOriginal = PrefabUtility.GetPrefabParent(vcam.gameObject) == null && PrefabUtility.GetPrefabObject(vcam.gameObject.transform) != null;

                        bool isPrefabOriginal2 = PrefabUtility.GetCorrespondingObjectFromSource(vcam.gameObject) == null && PrefabUtility.GetCorrespondingObjectFromSource(vcam.gameObject.transform) != null;
                  
                        bool isDisconnectedPrefabInstance = PrefabUtility.GetPrefabParent(vcam.gameObject) != null && PrefabUtility.GetPrefabObject(vcam.gameObject.transform) == null;`

Tried https://docs.unity3d.com/ScriptReference/PrefabUtility.GetPrefabAssetType.html too, but it said NotAPrefab


