### PR TITLE
3rdPersonFollow sets ReferenceLookAt to Nan. This is sufficient becau…

### DIFF
--- a/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -163,7 +163,7 @@ namespace Cinemachine
 
             curState.RawPosition = camPos;
             curState.RawOrientation = FollowTargetRotation;
-            curState.ReferenceLookAt = camPos + 1000.0f * (FollowTargetRotation * Vector3.forward);
+            curState.ReferenceLookAt = CameraState.kNoPoint;
             curState.ReferenceUp = up;
         }
 

--- a/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -163,7 +163,6 @@ namespace Cinemachine
 
             curState.RawPosition = camPos;
             curState.RawOrientation = FollowTargetRotation;
-            curState.ReferenceLookAt = CameraState.kNoPoint;
             curState.ReferenceUp = up;
         }
 


### PR DESCRIPTION
It turns out it is even more simple fix. 
It is enough to set 3rdPersonFollow's ReferenceLookAt to kNoPoint. We don't need to touch 3rdPersonAim, because it does not care what ReferenceLookAt is. If there is nothing hit by raycast, then ReferenceLookAt is set to camPos + fwd * AimDistance.
`return hasHit ? hitInfo.point : camPos + fwd * AimDistance;`