### PR TITLE
Vcam priority set from script did not trigger resort of active vcams.

### DIFF
--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -785,7 +785,7 @@ namespace Cinemachine
             int numCameras = core.VirtualCameraCount;
             if (!core.m_ActiveCamerasAreSorted)
             {
-                core.PseudoSortActiveCameras();
+                core.SortActiveCameras();
             }
             for (int i = 0; i < numCameras; ++i)
             {

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -783,10 +783,6 @@ namespace Cinemachine
             Camera outputCamera = OutputCamera;
             int mask = outputCamera == null ? ~0 : outputCamera.cullingMask;
             int numCameras = core.VirtualCameraCount;
-            if (!core.m_ActiveCamerasAreSorted)
-            {
-                core.SortActiveCameras();
-            }
             for (int i = 0; i < numCameras; ++i)
             {
                 var cam = core.GetVirtualCamera(i);

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -783,6 +783,10 @@ namespace Cinemachine
             Camera outputCamera = OutputCamera;
             int mask = outputCamera == null ? ~0 : outputCamera.cullingMask;
             int numCameras = core.VirtualCameraCount;
+            if (!core.m_ActiveCamerasAreSorted)
+            {
+                core.PseudoSortActiveCameras();
+            }
             for (int i = 0; i < numCameras; ++i)
             {
                 var cam = core.GetVirtualCamera(i);

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -158,6 +158,11 @@ namespace Cinemachine
         private List<CinemachineVirtualCameraBase> mActiveCameras = new List<CinemachineVirtualCameraBase>();
 
         internal bool m_ActiveCamerasAreSorted;
+        
+        /// <summary>
+        /// Sorts active cameras, so that the vcam with highest priority is first. When two vcams have the same
+        /// priority, then the one activated later is selected as higher priority.
+        /// </summary>
         internal void SortActiveCameras()
         {
             mActiveCameras.Sort(delegate(CinemachineVirtualCameraBase x, CinemachineVirtualCameraBase y)

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -178,8 +178,25 @@ namespace Cinemachine
                     activationSequenceOfMax = mActiveCameras[i].m_ActivationSequence;
                 }
             }
-
             (mActiveCameras[0], mActiveCameras[indexOfMax]) = (mActiveCameras[indexOfMax], mActiveCameras[0]); // swap
+        }
+
+        internal void SortActiveCameras()
+        {
+            mActiveCameras.Sort(delegate(CinemachineVirtualCameraBase x, CinemachineVirtualCameraBase y)
+            {
+                if (x.Priority < y.Priority || 
+                   (x.Priority == y.Priority && x.m_ActivationSequence < y.m_ActivationSequence))
+                {
+                    return 1;
+                }
+                if (x.Priority > y.Priority || 
+                   (x.Priority == y.Priority && x.m_ActivationSequence > y.m_ActivationSequence))
+                {
+                    return -1;
+                }
+                return 0;
+            });
         }
 
         /// <summary>

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -157,6 +157,31 @@ namespace Cinemachine
         /// <summary>List of all active ICinemachineCameras.</summary>
         private List<CinemachineVirtualCameraBase> mActiveCameras = new List<CinemachineVirtualCameraBase>();
 
+        internal bool m_ActiveCamerasAreSorted;
+
+        /// <summary>
+        /// Moves max priority vcam to index 0 in mActiveCameras. Not a full sort!
+        /// </summary>
+        internal void PseudoSortActiveCameras()
+        {
+            int indexOfMax = 0;
+            int priorityOfMax = int.MinValue;
+            uint activationSequenceOfMax = 0;
+            for (int i = 0; i < mActiveCameras.Count; ++i)
+            {
+                if (mActiveCameras[i].Priority > priorityOfMax ||
+                    (mActiveCameras[i].Priority == priorityOfMax && 
+                     mActiveCameras[i].m_ActivationSequence > activationSequenceOfMax))
+                {
+                    priorityOfMax = mActiveCameras[i].Priority;
+                    indexOfMax = i;
+                    activationSequenceOfMax = mActiveCameras[i].m_ActivationSequence;
+                }
+            }
+
+            (mActiveCameras[0], mActiveCameras[indexOfMax]) = (mActiveCameras[indexOfMax], mActiveCameras[0]); // swap
+        }
+
         /// <summary>
         /// List of all active Cinemachine Virtual Cameras for all brains.
         /// This list is kept sorted by priority.
@@ -172,6 +197,7 @@ namespace Cinemachine
             return mActiveCameras[index];
         }
 
+        private uint m_ActivationSequence;
         /// <summary>Called when a Cinemachine Virtual Camera is enabled.</summary>
         internal void AddActiveCamera(CinemachineVirtualCameraBase vcam)
         {
@@ -184,6 +210,7 @@ namespace Cinemachine
                 if (vcam.Priority >= mActiveCameras[insertIndex].Priority)
                     break;
 
+            vcam.m_ActivationSequence = m_ActivationSequence++;
             mActiveCameras.Insert(insertIndex, vcam);
         }
 
@@ -428,7 +455,7 @@ namespace Cinemachine
         /// send an activation event.
         /// </summary>
         /// <param name="vcam">The virtual camera being activated</param>
-        /// <param name="vcamFrom">The previouslay-active virtual camera (may be null)</param>
+        /// <param name="vcamFrom">The previously-active virtual camera (may be null)</param>
         public void GenerateCameraActivationEvent(ICinemachineCamera vcam, ICinemachineCamera vcamFrom)
         {
             if (vcam != null)

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -158,29 +158,6 @@ namespace Cinemachine
         private List<CinemachineVirtualCameraBase> mActiveCameras = new List<CinemachineVirtualCameraBase>();
 
         internal bool m_ActiveCamerasAreSorted;
-
-        /// <summary>
-        /// Moves max priority vcam to index 0 in mActiveCameras. Not a full sort!
-        /// </summary>
-        internal void PseudoSortActiveCameras()
-        {
-            int indexOfMax = 0;
-            int priorityOfMax = int.MinValue;
-            uint activationSequenceOfMax = 0;
-            for (int i = 0; i < mActiveCameras.Count; ++i)
-            {
-                if (mActiveCameras[i].Priority > priorityOfMax ||
-                    (mActiveCameras[i].Priority == priorityOfMax && 
-                     mActiveCameras[i].m_ActivationSequence > activationSequenceOfMax))
-                {
-                    priorityOfMax = mActiveCameras[i].Priority;
-                    indexOfMax = i;
-                    activationSequenceOfMax = mActiveCameras[i].m_ActivationSequence;
-                }
-            }
-            (mActiveCameras[0], mActiveCameras[indexOfMax]) = (mActiveCameras[indexOfMax], mActiveCameras[0]); // swap
-        }
-
         internal void SortActiveCameras()
         {
             mActiveCameras.Sort(delegate(CinemachineVirtualCameraBase x, CinemachineVirtualCameraBase y)

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -165,20 +165,10 @@ namespace Cinemachine
         /// </summary>
         internal void SortActiveCameras()
         {
-            mActiveCameras.Sort(delegate(CinemachineVirtualCameraBase x, CinemachineVirtualCameraBase y)
-            {
-                if (x.Priority < y.Priority || 
-                   (x.Priority == y.Priority && x.m_ActivationSequence < y.m_ActivationSequence))
-                {
-                    return 1;
-                }
-                if (x.Priority > y.Priority || 
-                   (x.Priority == y.Priority && x.m_ActivationSequence > y.m_ActivationSequence))
-                {
-                    return -1;
-                }
-                return 0;
-            });
+            mActiveCameras.Sort((x, y) => 
+                x.Priority < y.Priority || (x.Priority == y.Priority && x.m_ActivationId < y.m_ActivationId) ? 1 :
+                x.Priority > y.Priority || (x.Priority == y.Priority && x.m_ActivationId > y.m_ActivationId) ? -1 : 0);
+            m_ActiveCamerasAreSorted = true;
         }
 
         /// <summary>
@@ -209,7 +199,7 @@ namespace Cinemachine
                 if (vcam.Priority >= mActiveCameras[insertIndex].Priority)
                     break;
 
-            vcam.m_ActivationSequence = m_ActivationSequence++;
+            vcam.m_ActivationId = m_ActivationSequence++;
             mActiveCameras.Insert(insertIndex, vcam);
         }
 

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -347,7 +347,12 @@ namespace Cinemachine
 
         /// <summary>Get the Priority of the virtual camera.  This determines its placement
         /// in the CinemachineCore's queue of eligible shots.</summary>
-        public int Priority { get { return m_Priority; } set { m_Priority = value; } }
+        public int Priority { get { return m_Priority; }
+            set
+            {
+                m_Priority = value;
+                UpdateVcamPoolStatus();
+            } }
 
         /// <summary>Hint for blending to and from this virtual camera</summary>
         public enum BlendHint

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -580,7 +580,7 @@ namespace Cinemachine
             CinemachineCore.Instance.CameraDisabled(this);
         }
 
-        /// <summary>Base class implementation makes sure the priority queue is up-to-date when access.</summary>
+        /// <summary>Base class implementation makes sure the priority queue remains up-to-date.</summary>
         protected virtual void Update()
         {
             if (m_Priority != m_QueuePriority)

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -350,8 +350,11 @@ namespace Cinemachine
         public int Priority { get { return m_Priority; }
             set
             {
-                m_Priority = value;
-                UpdateVcamPoolStatus();
+                if (m_Priority != value)
+                {
+                    m_Priority = value;
+                    UpdateVcamPoolStatus();
+                }
             } }
 
         /// <summary>Hint for blending to and from this virtual camera</summary>

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -57,7 +57,9 @@ namespace Cinemachine
             + "other cameras and this camera.  Higher numbers have greater priority.")]
         public int m_Priority = 10;
 
-        internal uint m_ActivationId;
+        /// <summary>A sequence number that represents object activation order of vcams.  
+        /// Used for priority sorting.</summary>
+        internal int m_ActivationId;
 
         /// <summary>
         /// This must be set every frame at the start of the pipeline to relax the virtual camera's
@@ -583,7 +585,7 @@ namespace Cinemachine
         {
             if (m_Priority != m_QueuePriority)
             {
-                UpdateVcamPoolStatus();
+                UpdateVcamPoolStatus(); // Force a re-sort
             }
         }
 
@@ -634,11 +636,7 @@ namespace Cinemachine
         {
             CinemachineCore.Instance.RemoveActiveCamera(this);
             if (m_parentVcam == null && isActiveAndEnabled)
-            {
                 CinemachineCore.Instance.AddActiveCamera(this);
-                CinemachineCore.Instance.m_ActiveCamerasAreSorted = false;
-            }
-
             m_QueuePriority = m_Priority;
         }
 
@@ -652,7 +650,7 @@ namespace Cinemachine
         /// If it and its peers share the highest priority, then this vcam will become Live.</summary>
         public void MoveToTopOfPrioritySubqueue()
         {
-            UpdateVcamPoolStatus();
+            UpdateVcamPoolStatus(); // Force a re-sort
         }
 
         /// <summary>This is called to notify the component that a target got warped,

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -583,7 +583,6 @@ namespace Cinemachine
         {
             if (m_Priority != m_QueuePriority)
             {
-                CinemachineCore.Instance.m_ActiveCamerasAreSorted = false;
                 UpdateVcamPoolStatus();
             }
         }
@@ -635,7 +634,11 @@ namespace Cinemachine
         {
             CinemachineCore.Instance.RemoveActiveCamera(this);
             if (m_parentVcam == null && isActiveAndEnabled)
+            {
                 CinemachineCore.Instance.AddActiveCamera(this);
+                CinemachineCore.Instance.m_ActiveCamerasAreSorted = false;
+            }
+
             m_QueuePriority = m_Priority;
         }
 

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -57,6 +57,8 @@ namespace Cinemachine
             + "other cameras and this camera.  Higher numbers have greater priority.")]
         public int m_Priority = 10;
 
+        internal uint m_ActivationSequence;
+
         /// <summary>
         /// This must be set every frame at the start of the pipeline to relax the virtual camera's
         /// attachment to the target.  Range is 0...1.  
@@ -347,15 +349,7 @@ namespace Cinemachine
 
         /// <summary>Get the Priority of the virtual camera.  This determines its placement
         /// in the CinemachineCore's queue of eligible shots.</summary>
-        public int Priority { get { return m_Priority; }
-            set
-            {
-                if (m_Priority != value)
-                {
-                    m_Priority = value;
-                    UpdateVcamPoolStatus();
-                }
-            } }
+        public int Priority { get { return m_Priority; } set { m_Priority = value; } }
 
         /// <summary>Hint for blending to and from this virtual camera</summary>
         public enum BlendHint
@@ -584,11 +578,11 @@ namespace Cinemachine
             CinemachineCore.Instance.CameraDisabled(this);
         }
 
-        /// <summary>Base class implementation makes sure the priority queue remains up-to-date.</summary>
+        /// <summary>Base class implementation makes sure the priority queue is up-to-date when access.</summary>
         protected virtual void Update()
         {
             if (m_Priority != m_QueuePriority)
-                UpdateVcamPoolStatus();
+                CinemachineCore.Instance.m_ActiveCamerasAreSorted = false;
         }
 
         private bool mSlaveStatusUpdated = false;

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -57,7 +57,7 @@ namespace Cinemachine
             + "other cameras and this camera.  Higher numbers have greater priority.")]
         public int m_Priority = 10;
 
-        internal uint m_ActivationSequence;
+        internal uint m_ActivationId;
 
         /// <summary>
         /// This must be set every frame at the start of the pipeline to relax the virtual camera's
@@ -582,7 +582,10 @@ namespace Cinemachine
         protected virtual void Update()
         {
             if (m_Priority != m_QueuePriority)
+            {
                 CinemachineCore.Instance.m_ActiveCamerasAreSorted = false;
+                UpdateVcamPoolStatus();
+            }
         }
 
         private bool mSlaveStatusUpdated = false;


### PR DESCRIPTION
https://fogbugz.unity3d.com/f/cases/1293429/
The problem is that we start with three vcams: A, B, C.
A priority = 30
B priority = 20
C priority = 10

From script we change the priorities to A=0, B=0, C=10. Still, brain selects camera A, because that is at the top of the priority list (because it was not resorted).