### PR TITLE
Dev/compilation guards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.7.2] - 2020-12-31
+- CinemachineConfiner2D now handles cases where camera window is oversized
+- Bugfix (1293429) - Brain could choose vcam with not the highest priority in some cases.
+- Bugfix: SaveDuringPlay also works on prefab instances
+- Bugfix (1272146) - Adding vcam to a prefab asset no longer causes errors in console
+- Nested Scrub Bubble sample removed (filenames too long), available as embedded package
+
+
 ## [2.7.1] - 2020-11-14
 - New feature: CinemachineConfiner2D - Improved 2D confiner.
 - Added ApplyAfter option to ImpulseListener, to add control over the ordering of extensions
@@ -16,8 +24,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Storyboard Global Mute moved from Cinemachine menu to Cinemachine preferences.
 - Bugfix - long-idle vcams when reawakened sometimes had a single frame with a huge deltaTime
 - Bugfix - PostProcessing temporarily stopped being applied after exiting play mode
-- Bugfix (1272146) - Adding vcam to a prefab asset no longer causes errors in console
-- Bugfix (1293429) - Brain could choose vcam with not the highest priority in some cases.
 
 
 ## [2.6.3] - 2020-09-16

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: SaveDuringPlay also works on prefab instances
 - Bugfix (1272146) - Adding vcam to a prefab asset no longer causes errors in console
 - Nested Scrub Bubble sample removed (filenames too long), available as embedded package
+- Compilation guards for physics, animation, and imgui. Cinemachine does not hard depend on anything now.
 
 
 ## [2.7.1] - 2020-11-14

--- a/Editor/Editors/Cinemachine3rdPersonFollowEditor.cs
+++ b/Editor/Editors/Cinemachine3rdPersonFollowEditor.cs
@@ -1,9 +1,13 @@
+#if !UNITY_2019_3_OR_NEWER
+#define CINEMACHINE_PHYSICS
+#endif
+
 using UnityEngine;
 using UnityEditor;
-using System.Collections.Generic;
 
 namespace Cinemachine.Editor
 {
+#if CINEMACHINE_PHYSICS
     [CustomEditor(typeof(Cinemachine3rdPersonFollow))]
     internal class Cinemachine3rdPersonFollowEditor : BaseEditor<Cinemachine3rdPersonFollow>
     {
@@ -27,4 +31,5 @@ namespace Cinemachine.Editor
             }
         }
     }
+#endif
 }

--- a/Editor/Editors/CinemachineStateDrivenCameraEditor.cs
+++ b/Editor/Editors/CinemachineStateDrivenCameraEditor.cs
@@ -5,6 +5,7 @@ using UnityEditor.Animations;
 
 namespace Cinemachine.Editor
 {
+#if CINEMACHINE_UNITY_ANIMATION
     [CustomEditor(typeof(CinemachineStateDrivenCamera))]
     internal sealed class CinemachineStateDrivenCameraEditor
         : CinemachineVirtualCameraBaseEditor<CinemachineStateDrivenCamera>
@@ -451,4 +452,5 @@ namespace Cinemachine.Editor
                 };
         }
     }
+#endif
 }

--- a/Editor/Editors/CinemachineStateDrivenCameraEditor.cs
+++ b/Editor/Editors/CinemachineStateDrivenCameraEditor.cs
@@ -1,3 +1,7 @@
+#if !UNITY_2019_3_OR_NEWER
+#define CINEMACHINE_UNITY_ANIMATION
+#endif
+
 using System.Collections.Generic;
 using UnityEditor;
 using UnityEngine;

--- a/Editor/Menus/CinemachineMenu.cs
+++ b/Editor/Menus/CinemachineMenu.cs
@@ -1,6 +1,7 @@
 #if !UNITY_2019_3_OR_NEWER
 #define CINEMACHINE_PHYSICS
 #define CINEMACHINE_PHYSICS_2D
+#define CINEMACHINE_UNITY_ANIMATION
 #endif
 
 using UnityEngine;

--- a/Editor/Menus/CinemachineMenu.cs
+++ b/Editor/Menus/CinemachineMenu.cs
@@ -83,7 +83,8 @@ namespace Cinemachine.Editor
             vcam.m_Instructions[1].m_Blend.m_Style = CinemachineBlendDefinition.Style.EaseInOut;
             vcam.m_Instructions[1].m_Blend.m_Time = 2f;
         }
-
+        
+#if CINEMACHINE_UNITY_ANIMATION
         [MenuItem(m_CinemachineGameObjectRootMenu + "State-Driven Camera", false, m_MenuPriority)]
         private static void CreateStateDivenCamera()
         {
@@ -99,6 +100,7 @@ namespace Cinemachine.Editor
             // Give it a child
             Undo.SetTransformParent(CreateDefaultVirtualCamera().transform, go.transform, "create state driven camera");
         }
+#endif
 
 #if CINEMACHINE_PHYSICS
         [MenuItem(m_CinemachineGameObjectRootMenu + "ClearShot Camera", false, m_MenuPriority)]

--- a/Editor/com.unity.cinemachine.Editor.asmdef
+++ b/Editor/com.unity.cinemachine.Editor.asmdef
@@ -68,6 +68,11 @@
             "name": "com.unity.timeline",
             "expression": "1.5.0-preview.5",
             "define": "CINEMACHINE_TIMELINE_1_5_0"
+        },
+        {
+            "name": "com.unity.modules.animation",
+            "expression": "1.0.0",
+            "define": "#if CINEMACHINE_UNITY_ANIMATION"
         }
     ],
     "noEngineReferences": false

--- a/Editor/com.unity.cinemachine.Editor.asmdef
+++ b/Editor/com.unity.cinemachine.Editor.asmdef
@@ -72,7 +72,12 @@
         {
             "name": "com.unity.modules.animation",
             "expression": "1.0.0",
-            "define": "#if CINEMACHINE_UNITY_ANIMATION"
+            "define": "CINEMACHINE_UNITY_ANIMATION"
+        },
+        {
+            "name": "com.unity.modules.imgui",
+            "expression": "1.0.0",
+            "define": "CINEMACHINE_UNITY_IMGUI"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/Behaviours/CinemachineBlendListCamera.cs
+++ b/Runtime/Behaviours/CinemachineBlendListCamera.cs
@@ -1,3 +1,7 @@
+#if !UNITY_2019_3_OR_NEWER
+#define CINEMACHINE_UNITY_IMGUI
+#endif
+
 using Cinemachine.Utility;
 using System;
 using System.Collections.Generic;
@@ -274,21 +278,19 @@ namespace Cinemachine
         /// Will only be called if Unity Editor - never in build
         private void OnGuiHandler()
         {
-
+#if CINEMACHINE_UNITY_IMGUI
             if (!m_ShowDebugText)
                 CinemachineDebug.ReleaseScreenPos(this);
             else
             {
-#if CINEMACHINE_UNITY_IMGUI
                 var sb = CinemachineDebug.SBFromPool();
                 sb.Append(Name); sb.Append(": "); sb.Append(Description);
                 string text = sb.ToString();
                 Rect r = CinemachineDebug.GetScreenPos(this, text, GUI.skin.box);
                 GUI.Label(r, text, GUI.skin.box);
                 CinemachineDebug.ReturnToPool(sb);
-#endif
             }
-
+#endif
         }
 
         CameraState m_State = CameraState.Default;

--- a/Runtime/Behaviours/CinemachineBlendListCamera.cs
+++ b/Runtime/Behaviours/CinemachineBlendListCamera.cs
@@ -274,17 +274,21 @@ namespace Cinemachine
         /// Will only be called if Unity Editor - never in build
         private void OnGuiHandler()
         {
+
             if (!m_ShowDebugText)
                 CinemachineDebug.ReleaseScreenPos(this);
             else
             {
+#if CINEMACHINE_UNITY_IMGUI
                 var sb = CinemachineDebug.SBFromPool();
                 sb.Append(Name); sb.Append(": "); sb.Append(Description);
                 string text = sb.ToString();
                 Rect r = CinemachineDebug.GetScreenPos(this, text, GUI.skin.box);
                 GUI.Label(r, text, GUI.skin.box);
                 CinemachineDebug.ReturnToPool(sb);
+#endif
             }
+
         }
 
         CameraState m_State = CameraState.Default;

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -244,7 +244,9 @@ namespace Cinemachine
             {
                 // Show the active camera and blend
                 var sb = CinemachineDebug.SBFromPool();
+#if CINEMACHINE_UNITY_IMGUI
                 Color color = GUI.color;
+#endif
                 sb.Length = 0;
                 sb.Append("CM ");
                 sb.Append(gameObject.name);
@@ -252,7 +254,9 @@ namespace Cinemachine
                 if (SoloCamera != null)
                 {
                     sb.Append("SOLO ");
+#if CINEMACHINE_UNITY_IMGUI
                     GUI.color = GetSoloGUIColor();
+#endif
                 }
 
                 if (IsBlending)
@@ -270,9 +274,11 @@ namespace Cinemachine
                     }
                 }
                 string text = sb.ToString();
+#if CINEMACHINE_UNITY_IMGUI
                 Rect r = CinemachineDebug.GetScreenPos(this, text, GUI.skin.box);
                 GUI.Label(r, text, GUI.skin.box);
                 GUI.color = color;
+#endif
                 CinemachineDebug.ReturnToPool(sb);
             }
         }

--- a/Runtime/Behaviours/CinemachineBrain.cs
+++ b/Runtime/Behaviours/CinemachineBrain.cs
@@ -1,3 +1,7 @@
+#if !UNITY_2019_3_OR_NEWER
+#define CINEMACHINE_UNITY_IMGUI
+#endif
+
 using Cinemachine.Utility;
 using System;
 using System.Collections;
@@ -238,15 +242,14 @@ namespace Cinemachine
 
         private void OnGuiHandler()
         {
+#if CINEMACHINE_UNITY_IMGUI
             if (!m_ShowDebugText)
                 CinemachineDebug.ReleaseScreenPos(this);
             else
             {
                 // Show the active camera and blend
                 var sb = CinemachineDebug.SBFromPool();
-#if CINEMACHINE_UNITY_IMGUI
                 Color color = GUI.color;
-#endif
                 sb.Length = 0;
                 sb.Append("CM ");
                 sb.Append(gameObject.name);
@@ -254,9 +257,7 @@ namespace Cinemachine
                 if (SoloCamera != null)
                 {
                     sb.Append("SOLO ");
-#if CINEMACHINE_UNITY_IMGUI
                     GUI.color = GetSoloGUIColor();
-#endif
                 }
 
                 if (IsBlending)
@@ -274,13 +275,12 @@ namespace Cinemachine
                     }
                 }
                 string text = sb.ToString();
-#if CINEMACHINE_UNITY_IMGUI
                 Rect r = CinemachineDebug.GetScreenPos(this, text, GUI.skin.box);
                 GUI.Label(r, text, GUI.skin.box);
                 GUI.color = color;
-#endif
                 CinemachineDebug.ReturnToPool(sb);
             }
+#endif
         }
 
 #if UNITY_EDITOR

--- a/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
+++ b/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
@@ -5,6 +5,7 @@ using UnityEngine;
 
 namespace Cinemachine
 {
+#if CINEMACHINE_UNITY_ANIMATION
     /// <summary>
     /// This is a virtual camera "manager" that owns and manages a collection
     /// of child Virtual Cameras.  These child vcams are mapped to individual states in
@@ -552,4 +553,5 @@ namespace Cinemachine
             return blend;
         }
     }
+#endif
 }

--- a/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
+++ b/Runtime/Behaviours/CinemachineStateDrivenCamera.cs
@@ -1,3 +1,7 @@
+#if !UNITY_2019_3_OR_NEWER
+#define CINEMACHINE_UNITY_ANIMATION
+#endif
+
 using Cinemachine.Utility;
 using System;
 using System.Collections.Generic;

--- a/Runtime/Components/Cinemachine3rdPersonFollow.cs
+++ b/Runtime/Components/Cinemachine3rdPersonFollow.cs
@@ -1,7 +1,6 @@
-//#if !UNITY_2019_3_OR_NEWER
+#if !UNITY_2019_3_OR_NEWER
 #define CINEMACHINE_PHYSICS
-#define CINEMACHINE_PHYSICS_2D
-//#endif
+#endif
 
 using UnityEngine;
 using Cinemachine.Utility;

--- a/Runtime/Core/CinemachineDebug.cs
+++ b/Runtime/Core/CinemachineDebug.cs
@@ -17,6 +17,7 @@ namespace Cinemachine.Utility
                 mClients.Remove(client);
         }
 
+#if CINEMACHINE_UNITY_IMGUI
         /// <summary>Reserve an on-screen rectangle for debugging output.</summary>
         /// <param name="client">The client caller.  This is used as a handle.</param>
         /// <param name="text">Sample text, for determining rectangle size</param>
@@ -44,6 +45,7 @@ namespace Cinemachine.Utility
             }
             return new Rect(pos, size);
         }
+#endif
 
         /// <summary>
         /// Delegate for OnGUI debugging.  

--- a/Runtime/Core/CinemachineDebug.cs
+++ b/Runtime/Core/CinemachineDebug.cs
@@ -1,3 +1,7 @@
+#if !UNITY_2019_3_OR_NEWER
+#define CINEMACHINE_UNITY_IMGUI
+#endif
+
 using UnityEngine;
 using System.Collections.Generic;
 using System.Text;
@@ -9,6 +13,7 @@ namespace Cinemachine.Utility
     {
         static HashSet<Object> mClients;
 
+#if CINEMACHINE_UNITY_IMGUI
         /// <summary>Release a screen rectangle previously obtained through GetScreenPos()</summary>
         /// <param name="client">The client caller.  Used as a handle.</param>
         public static void ReleaseScreenPos(Object client)
@@ -16,8 +21,7 @@ namespace Cinemachine.Utility
             if (mClients != null && mClients.Contains(client))
                 mClients.Remove(client);
         }
-
-#if CINEMACHINE_UNITY_IMGUI
+        
         /// <summary>Reserve an on-screen rectangle for debugging output.</summary>
         /// <param name="client">The client caller.  This is used as a handle.</param>
         /// <param name="text">Sample text, for determining rectangle size</param>

--- a/Runtime/com.unity.cinemachine.asmdef
+++ b/Runtime/com.unity.cinemachine.asmdef
@@ -74,6 +74,11 @@
             "name": "com.unity.modules.animation",
             "expression": "1.0.0",
             "define": "CINEMACHINE_UNITY_ANIMATION"
+        },
+        {
+            "name": "com.unity.modules.imgui",
+            "expression": "1.0.0",
+            "define": "CINEMACHINE_UNITY_IMGUI"
         }
     ],
     "noEngineReferences": false

--- a/Runtime/com.unity.cinemachine.asmdef
+++ b/Runtime/com.unity.cinemachine.asmdef
@@ -15,7 +15,7 @@
     "allowUnsafeCode": false,
     "overrideReferences": false,
     "precompiledReferences": [
-    	"clipper_library.dll"
+        "clipper_library.dll"
     ],
     "autoReferenced": true,
     "defineConstraints": [],
@@ -69,6 +69,11 @@
             "name": "com.unity.inputsystem",
             "expression": "1.0.0-preview",
             "define": "CINEMACHINE_UNITY_INPUTSYSTEM"
+        },
+        {
+            "name": "com.unity.modules.animation",
+            "expression": "1.0.0",
+            "define": "CINEMACHINE_UNITY_ANIMATION"
         }
     ],
     "noEngineReferences": false

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
     "name": "com.unity.cinemachine",
     "displayName": "Cinemachine",
-    "version": "2.7.1",
+    "version": "2.7.2-pre.1",
     "unity": "2018.4",
     "description": "Smart camera tools for passionate creators. \n\nNew for 2.7.1: Are you looking for the Cinemachine menu?  It has moved to the GameObject menu.\n\nIMPORTANT NOTE: If you are upgrading from the legacy Asset Store version of Cinemachine, delete the Cinemachine asset from your project BEFORE installing this version from the Package Manager.",
     "keywords": [ "camera", "follow", "rig", "fps", "cinematography", "aim", "orbit", "cutscene", "cinematic", "collision", "freelook", "cinemachine", "compose", "composition", "dolly", "track", "clearshot", "noise", "framing", "handheld", "lens", "impulse" ],


### PR DESCRIPTION
Added compilation guards for physics (thirdpersoncamera), animation (statedrivencamera), imgui (CinemachineDebug, Brain, BlendListCamera).

Cinemachine can be added to a totally empty Unity (empty manifest, except for cinemachine).