### PR TITLE
CMCL-202: fix broken reset in PositionPredictor

### DIFF
--- a/Runtime/Core/Predictor.cs
+++ b/Runtime/Core/Predictor.cs
@@ -10,7 +10,6 @@ namespace Cinemachine.Utility
         Vector3 m_Velocity;
         Vector3 m_SmoothDampVelocity;
         Vector3 m_Pos;
-        float m_SqrSpeed;
         bool m_HavePos;
 
         /// <summary>
@@ -36,7 +35,7 @@ namespace Cinemachine.Utility
         { 
             m_HavePos = false; 
             m_SmoothDampVelocity = Vector3.zero; 
-            m_SqrSpeed = 0;
+            m_Velocity = Vector3.zero;
         }
 
         /// <summary>Add a new target position to the history buffer</summary>
@@ -50,12 +49,10 @@ namespace Cinemachine.Utility
             if (m_HavePos && deltaTime > UnityVectorExtensions.Epsilon)
             {
                 var vel = (pos - m_Pos) / deltaTime;
-                var sqrSpeed = vel.sqrMagnitude;
-                bool slowing = sqrSpeed < m_SqrSpeed;
+                bool slowing = vel.sqrMagnitude < m_Velocity.sqrMagnitude;
                 m_Velocity = Vector3.SmoothDamp(
                     m_Velocity, vel, ref m_SmoothDampVelocity, Smoothing / (slowing ? 30 : 10), 
                     float.PositiveInfinity, deltaTime);
-                m_SqrSpeed = m_Velocity.sqrMagnitude;
             }
             m_Pos = pos;
             m_HavePos = true;


### PR DESCRIPTION
bug reported here: https://forum.unity.com/threads/framingtransposer-has-residual-prediction-velocity-after-being-snapped.1037950/