### PR TITLE
storyboard hotreload bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,6 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [2.7.3]
-- Bugfix: CM StoryBoard had a 1 pixel border.
-
 ## [2.7.2] - 2020-12-31
 - CinemachineConfiner2D now handles cases where camera window is oversized
 - Bugfix (1293429) - Brain could choose vcam with not the highest priority in some cases.
@@ -15,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix (1290171) - Impulse manager was not cleared at playmode start
 - Nested Scrub Bubble sample removed (filenames too long), available now as embedded package
 - Compilation guards for physics, animation, and imgui. Cinemachine does not hard depend on anything now.
+- Bugfix: CM StoryBoard had a 1 pixel border.
 
 
 ## [2.7.1] - 2020-11-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Nested Scrub Bubble sample removed (filenames too long), available now as embedded package
 - Compilation guards for physics, animation, and imgui. Cinemachine does not hard depend on anything now.
 - Bugfix: CM StoryBoard had a 1 pixel border.
+- Bugfix: CM StoryBoard lost viewport reference after hot reload.
 
 
 ## [2.7.1] - 2020-11-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.7.3]
+- Bugfix: CM StoryBoard had a 1 pixel border.
+
 ## [2.7.2] - 2020-12-31
 - CinemachineConfiner2D now handles cases where camera window is oversized
 - Bugfix (1293429) - Brain could choose vcam with not the highest priority in some cases.

--- a/Runtime/Behaviours/CinemachineStoryboard.cs
+++ b/Runtime/Behaviours/CinemachineStoryboard.cs
@@ -294,8 +294,6 @@ namespace Cinemachine
                 ci.mRawImage.rectTransform.localScale = scale;
                 ci.mRawImage.rectTransform.ForceUpdateRectTransforms();
                 ci.mRawImage.rectTransform.sizeDelta = screen.size;
-
-
             }
         }
 

--- a/Runtime/Behaviours/CinemachineStoryboard.cs
+++ b/Runtime/Behaviours/CinemachineStoryboard.cs
@@ -2,10 +2,12 @@
 #define CINEMACHINE_UGUI
 #endif
 
+using UnityEditor.SceneManagement;
 using UnityEngine;
 
 #if CINEMACHINE_UGUI
 using System.Collections.Generic;
+using UnityEditor.SearchService;
 
 namespace Cinemachine
 {
@@ -172,7 +174,7 @@ namespace Cinemachine
                         if (child != null && child.name == CanvasName)
                         {
                             ci.mCanvas = child.gameObject;
-                            ci.mViewport = ci.mCanvas.GetComponentInChildren<RectTransform>();
+                            ci.mViewport = ci.mCanvas.GetComponentsInChildren<RectTransform>()[1]; // 0 is mCanvas
                             ci.mRawImage = ci.mCanvas.GetComponentInChildren<UnityEngine.UI.RawImage>();
                         }
                     }
@@ -292,6 +294,8 @@ namespace Cinemachine
                 ci.mRawImage.rectTransform.localScale = scale;
                 ci.mRawImage.rectTransform.ForceUpdateRectTransforms();
                 ci.mRawImage.rectTransform.sizeDelta = screen.size;
+
+
             }
         }
 

--- a/Runtime/Behaviours/CinemachineStoryboard.cs
+++ b/Runtime/Behaviours/CinemachineStoryboard.cs
@@ -251,7 +251,7 @@ namespace Cinemachine
                 ci.mViewport.localRotation = Quaternion.identity;
                 ci.mViewport.localScale = Vector3.one;
                 ci.mViewport.ForceUpdateRectTransforms();
-                ci.mViewport.sizeDelta = new Vector2(screen.width - Mathf.Abs(wipeAmount), screen.height);
+                ci.mViewport.sizeDelta = new Vector2(screen.width + 1 - Mathf.Abs(wipeAmount), screen.height + 1);
 
                 Vector2 scale = Vector2.one;
                 if (m_Image != null

--- a/Runtime/Behaviours/CinemachineStoryboard.cs
+++ b/Runtime/Behaviours/CinemachineStoryboard.cs
@@ -1,13 +1,10 @@
 ﻿#if !UNITY_2019_1_OR_NEWER
 #define CINEMACHINE_UGUI
 #endif
-
-using UnityEditor.SceneManagement;
 using UnityEngine;
 
 #if CINEMACHINE_UGUI
 using System.Collections.Generic;
-using UnityEditor.SearchService;
 
 namespace Cinemachine
 {


### PR DESCRIPTION
Bug was caused by GetComponentInChildren. This returned mCanvas, instead of Viewport. 