### PR TITLE
Removed condition which caused the flick.

### DIFF
--- a/Runtime/Components/CinemachineFramingTransposer.cs
+++ b/Runtime/Components/CinemachineFramingTransposer.cs
@@ -518,7 +518,7 @@ namespace Cinemachine
 
             // Optionally allow undamped camera orientation change
             Quaternion localToWorld = curState.RawOrientation;
-            if (previousStateIsValid && m_TargetMovementOnly && m_prevRotation != localToWorld)
+            if (previousStateIsValid && m_TargetMovementOnly)
             {
                 var q = localToWorld * Quaternion.Inverse(m_prevRotation);
                 m_PreviousCameraPosition = TrackedPoint + q * (m_PreviousCameraPosition - TrackedPoint);


### PR DESCRIPTION
The fix is tiny, but was not easy to find :). 

!= is not precise enough (it's overloaded with a dot equal)
```
private static bool IsEqualUsingDot(float dot)
    {
      return (double) dot > 0.9999989867210388;
    }
```
