### PR TITLE
Input system enabled/disabled

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: CM StoryBoard lost viewport reference after hot reload
 - Bugfix: FramingTransposer's TargetMovementOnly damping caused a flick.
 - Bugfix: InheritPosition did not work with SimpleFollow binding mode
+- Bugfix: Checking whether the Input Action is enabled before using it.
 
 
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,7 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: CM StoryBoard lost viewport reference after hot reload
 - Bugfix: FramingTransposer's TargetMovementOnly damping caused a flick.
 - Bugfix: InheritPosition did not work with SimpleFollow binding mode
-- Bugfix: Checking whether the Input Action is enabled before using it.
+- Bugfix: Checking whether the Input Action passed to CinemachineInputHandler is enabled before using it.
 
 
 

--- a/Runtime/Helpers/CinemachineInputProvider.cs
+++ b/Runtime/Helpers/CinemachineInputProvider.cs
@@ -69,12 +69,11 @@ namespace Cinemachine
         /// <returns>The cached action for the player specified in PlayerIndex</returns>
         protected InputAction ResolveForPlayer(int axis, InputActionReference actionRef)
         {
-            if (!actionRef.action.enabled)
-                return null;
-            
             if (axis < 0 || axis >= NUM_AXES)
                 return null;
             if (actionRef == null || actionRef.action == null)
+                return null;
+            if (!actionRef.action.enabled)
                 return null;
             if (m_cachedActions == null || m_cachedActions.Length != NUM_AXES)
                 m_cachedActions = new InputAction[NUM_AXES];

--- a/Runtime/Helpers/CinemachineInputProvider.cs
+++ b/Runtime/Helpers/CinemachineInputProvider.cs
@@ -69,6 +69,9 @@ namespace Cinemachine
         /// <returns>The cached action for the player specified in PlayerIndex</returns>
         protected InputAction ResolveForPlayer(int axis, InputActionReference actionRef)
         {
+            if (!actionRef.action.enabled)
+                return null;
+            
             if (axis < 0 || axis >= NUM_AXES)
                 return null;
             if (actionRef == null || actionRef.action == null)

--- a/Runtime/Helpers/CinemachineInputProvider.cs
+++ b/Runtime/Helpers/CinemachineInputProvider.cs
@@ -71,9 +71,7 @@ namespace Cinemachine
         {
             if (axis < 0 || axis >= NUM_AXES)
                 return null;
-            if (actionRef == null || actionRef.action == null)
-                return null;
-            if (!actionRef.action.enabled)
+            if (actionRef == null || actionRef.action == null || !actionRef.action.enabled)
                 return null;
             if (m_cachedActions == null || m_cachedActions.Length != NUM_AXES)
                 m_cachedActions = new InputAction[NUM_AXES];


### PR DESCRIPTION
https://forum.unity.com/threads/input-action-reference-wont-disable-on-cinemachine.1052192/

We don't check whether Player Input is enabled, before using it.