### PR TITLE
Don't use scriptable object mono path to get CM install path

### DIFF
--- a/Editor/Utility/ScriptableObjectUtility.cs
+++ b/Editor/Utility/ScriptableObjectUtility.cs
@@ -15,47 +15,23 @@ namespace Cinemachine.Editor
         /// </summary>
         public static string kPackageRoot = "Packages/com.unity.cinemachine";
 
-        /// <summary>Get the Cinemachine package install path.  Works whether CM is
-        /// a packman package or an ordinary asset.</summary>
+        /// <summary>Get the Cinemachine package install path.</summary>
         public static string CinemachineInstallPath
         {
             get
             {
-                // First see if we're a UPM package - use some asset that we expect to find
-                string path = Path.GetFullPath(kPackageRoot + "/Editor/EditorResources/cm_logo_sm.png");
-                int index = path.LastIndexOf("/Editor");
-                if (index < 0 || !File.Exists(path))
-                {
-                    // Try as an ordinary asset
-                    ScriptableObject dummy = ScriptableObject.CreateInstance<ScriptableObjectUtility>();
-                    path = AssetDatabase.GetAssetPath(MonoScript.FromScriptableObject(dummy));
-                    if (path.Length > 0)
-                        path = Path.GetFullPath(path);
-                    DestroyImmediate(dummy);
-                }
+                string path = Path.GetFullPath(kPackageRoot);
                 path = path.Replace('\\', '/'); // because of GetFullPath()
-                index = path.LastIndexOf("/Editor");
-                if (index >= 0)
-                    path = path.Substring(0, index);
-                if (path.Length > 0)
-                    path = Path.GetFullPath(path);  // stupid backslashes
                 return path;
             }
         }
 
-        /// <summary>Get the Cinemachine package install path.  Works whether CM is
-        /// a packman package or an ordinary asset.</summary>
+        /// <summary>Get the relative Cinemachine package install path.</summary>
         public static string CinemachineRealativeInstallPath
         {
             get
             {
-                ScriptableObject dummy = ScriptableObject.CreateInstance<ScriptableObjectUtility>();
-                var path = AssetDatabase.GetAssetPath(MonoScript.FromScriptableObject(dummy));
-                DestroyImmediate(dummy);
-                var index = path.LastIndexOf("/Editor");
-                if (index >= 0)
-                    path = path.Substring(0, index);
-                return path;
+                return kPackageRoot;
             }
         }
 

--- a/Tests/Editor/ScriptableObjectUtilityTests.cs
+++ b/Tests/Editor/ScriptableObjectUtilityTests.cs
@@ -1,0 +1,24 @@
+using UnityEngine;
+using UnityEngine.TestTools;
+using NUnit.Framework;
+using Cinemachine.Editor;
+using System.IO;
+
+[TestFixture]   
+public class ScriptableObjectUtilityTests
+{
+    [Test]
+    public void CinemachineInstallPathIsValid()
+    {
+        var pathToCmLogo = Path.Combine(ScriptableObjectUtility.CinemachineInstallPath, "Editor/EditorResources/cm_logo_sm.png");
+        Assert.That(File.Exists(pathToCmLogo));
+    }
+
+    [Test]
+    public void CinemachineInstallRelativePathIsValid()
+    {
+        var relativePathToCmLogo = Path.Combine(ScriptableObjectUtility.CinemachineRealativeInstallPath, "Editor/EditorResources/cm_logo_sm.png");
+        var pathToCmLogo = Path.GetFullPath(relativePathToCmLogo);
+        Assert.That(File.Exists(pathToCmLogo));
+    }
+}

--- a/Tests/Editor/ScriptableObjectUtilityTests.cs
+++ b/Tests/Editor/ScriptableObjectUtilityTests.cs
@@ -1,5 +1,3 @@
-using UnityEngine;
-using UnityEngine.TestTools;
 using NUnit.Framework;
 using Cinemachine.Editor;
 using System.IO;

--- a/Tests/Editor/ScriptableObjectUtilityTests.cs.meta
+++ b/Tests/Editor/ScriptableObjectUtilityTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ab4b083fcd6654652a9b8d3378e6e1b6
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Just assume we're in a package and use straightforward relative path resolution. Drops the non-upm package support based on substring manipulation.
Also added unit tests.
Fixes CMCL-223.