### PR TITLE
set cancel_old_ci to true to reduce yamato load

### DIFF
--- a/.yamato/package-test.yml
+++ b/.yamato/package-test.yml
@@ -79,6 +79,7 @@ test_trigger:
       - targets:
           only:
             - "/.*/"
+    cancel_old_ci: true
   dependencies:
     - .yamato/package-pack.yml#pack
     {% for editor in test_editors %}


### PR DESCRIPTION
Recommended by the Yamato team. This becomes the default behaviour March 1st anyway.