### PR TITLE
CMCL-537: Lookahead Time does not work in v2.8.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.8.2] - 2021-10-27
+- Regression fix: Lookahead works again.
+
+
 ## [2.8.1] - 2021-09-24
 - Bugfix: OnTargetObjectWarped() did not work properly for 3rdPersonFollow.
 - Bugfix: POV did not properly handle overridden up.

--- a/Runtime/AssemblyInfo.cs
+++ b/Runtime/AssemblyInfo.cs
@@ -1,3 +1,3 @@
 ﻿using System.Runtime.CompilerServices;
 [assembly: InternalsVisibleTo("com.unity.cinemachine.editor")]
-[assembly: InternalsVisibleTo("com.unity.cinemachine.tests")]
+[assembly: InternalsVisibleTo("Cinemachine.Tests")]

--- a/Runtime/Components/CinemachineFramingTransposer.cs
+++ b/Runtime/Components/CinemachineFramingTransposer.cs
@@ -335,7 +335,7 @@ namespace Cinemachine
 
         /// <summary>State information for damping</summary>
         Vector3 m_PreviousCameraPosition = Vector3.zero;
-        PositionPredictor m_Predictor = new PositionPredictor();
+        internal PositionPredictor m_Predictor = new PositionPredictor();
 
         /// <summary>Internal API for inspector</summary>
         public Vector3 TrackedPoint { get; private set; }

--- a/Runtime/Core/CinemachineVirtualCameraBase.cs
+++ b/Runtime/Core/CinemachineVirtualCameraBase.cs
@@ -789,7 +789,7 @@ namespace Cinemachine
         protected void UpdateTargetCache()
         {
             var target = ResolveFollow(Follow);
-            FollowTargetChanged |= target != m_CachedFollowTarget;
+            FollowTargetChanged = target != m_CachedFollowTarget;
             if (FollowTargetChanged)
             {
                 m_CachedFollowTarget = target;
@@ -802,7 +802,7 @@ namespace Cinemachine
                 }
             }
             target = ResolveLookAt(LookAt);
-            LookAtTargetChanged |= target != m_CachedLookAtTarget;
+            LookAtTargetChanged = target != m_CachedLookAtTarget;
             if (LookAtTargetChanged)
             {
                 m_CachedLookAtTarget = target;

--- a/Tests/Runtime/LookaheadTests.cs
+++ b/Tests/Runtime/LookaheadTests.cs
@@ -1,0 +1,89 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+using Cinemachine;
+
+namespace Tests.Runtime
+{
+    [TestFixture]
+    public class LookaheadTests : CinemachineFixtureBase
+    {
+        CinemachineVirtualCamera m_VCam;
+        CinemachineComposer m_Composer;
+        CinemachineFramingTransposer m_FramingTransposer;
+        Transform m_Target;
+
+        [SetUp]
+        public override void SetUp()
+        {
+            // Camera
+            CreateGameObject("MainCamera", typeof(Camera), typeof(CinemachineBrain));
+            m_Target = CreateGameObject("Target Object").transform;
+
+            // Source vcam
+            m_VCam = CreateGameObject("Source CM Vcam", typeof(CinemachineVirtualCamera)).GetComponent<CinemachineVirtualCamera>();
+            m_VCam.Follow = m_Target;
+            m_VCam.LookAt = m_Target;
+            m_FramingTransposer = m_VCam.AddCinemachineComponent<CinemachineFramingTransposer>();
+            m_Composer = m_VCam.AddCinemachineComponent<CinemachineComposer>();
+            m_FramingTransposer.m_LookaheadSmoothing = m_Composer.m_LookaheadSmoothing = 0.3f;
+            m_FramingTransposer.m_LookaheadTime = m_Composer.m_LookaheadTime = 10;
+
+            base.SetUp();
+        }
+
+        [UnityTest]
+        public IEnumerator TargetsChanged()
+        {
+            Assert.That(m_VCam.FollowTargetChanged, Is.False);
+            Assert.That(m_VCam.LookAtTargetChanged, Is.False);
+
+            yield return null;
+            Assert.That(m_VCam.FollowTargetChanged, Is.False);
+            Assert.That(m_VCam.LookAtTargetChanged, Is.False);
+            
+            var newTarget = CreateGameObject("Target Object 2").transform;
+            m_VCam.LookAt = newTarget;
+
+            yield return null;
+            
+            Assert.That(m_VCam.FollowTargetChanged, Is.False);
+            Assert.That(m_VCam.LookAtTargetChanged, Is.True);
+
+            m_VCam.Follow = newTarget;
+
+            yield return null;
+            
+            Assert.That(m_VCam.FollowTargetChanged, Is.True);
+            Assert.That(m_VCam.LookAtTargetChanged, Is.False);
+
+            m_VCam.Follow = m_Target;
+            m_VCam.LookAt = m_Target;
+
+            yield return null;
+            
+            Assert.That(m_VCam.FollowTargetChanged, Is.True);
+            Assert.That(m_VCam.LookAtTargetChanged, Is.True);
+        }
+
+        [UnityTest]
+        public IEnumerator LookaheadDelta()
+        {
+            var delta = m_Composer.m_Predictor.PredictPositionDelta(m_Composer.m_LookaheadTime);
+            Assert.That(delta.sqrMagnitude > 0, Is.False);
+            
+            delta = m_FramingTransposer.m_Predictor.PredictPositionDelta(m_FramingTransposer.m_LookaheadTime);
+            Assert.That(delta.sqrMagnitude > 0, Is.False);
+            
+            m_Target.Translate(10, 0, 0);
+            yield return null;
+            
+            delta = m_Composer.m_Predictor.PredictPositionDelta(m_Composer.m_LookaheadTime);
+            Assert.That(delta.sqrMagnitude > 0, Is.True);
+            
+            delta = m_FramingTransposer.m_Predictor.PredictPositionDelta(m_FramingTransposer.m_LookaheadTime);
+            Assert.That(delta.sqrMagnitude > 0, Is.True);
+        }
+    }
+}

--- a/Tests/Runtime/LookaheadTests.cs.meta
+++ b/Tests/Runtime/LookaheadTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6f519ca69bd041a48f57459cc0388d67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR

* FollowTargetChanged and LookAtTargetChanged was always true, if it became true once, because of the || operator. Changed |= to =

* Internals are visible to tests now. Added unit tests for lookahead. Changed framing transposer predictor to internal

* clean up

* Changelog

Co-authored-by: Gregory Labute <gregoryl@unity3d.com>

[Delete any line or section that does not apply]
### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [x] Added an automated test
- [ ] Passed all automated tests
- [ ] Manually tested 

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
