### PR TITLE
CMCL-477: Expose AimTarget (#324)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: Input system should be read only once per render frame.
 - Bugfix: Blends were sometimes incorrect when src or dst camera is looking along world up axis.
 - Bugfix: Improve accuracy of Group Framing.
+- Cinemachine3rdPersonAim exposes AimTarget, which is the position of where the player would hit.
 
 
 ## [2.8.0] - 2021-07-13

--- a/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
+++ b/Runtime/Behaviours/Cinemachine3rdPersonAim.cs
@@ -44,6 +44,11 @@ namespace Cinemachine
             + "May be null, in which case no on-screen indicator will appear")]
         public RectTransform AimTargetReticle;
 
+        /// <summary>World space position of where the player would hit if a projectile were to 
+        /// be fired from the player origin.  This may be different
+        /// from state.ReferenceLookAt due to camera offset from player origin.</summary>
+        public Vector3 AimTarget { get; private set; }
+
         private void OnValidate()
         {
             AimDistance = Mathf.Max(1, AimDistance);
@@ -74,46 +79,38 @@ namespace Cinemachine
         {
             if (!brain.IsLive(VirtualCamera) || brain.OutputCamera == null)
                 CinemachineCore.CameraUpdatedEvent.RemoveListener(DrawReticle);
-            else
-            {
-                var player = VirtualCamera.Follow;
-                if (AimTargetReticle != null && player != null)
-                {
-                    // Adjust for actual player aim target (may be different due to offset)
-                    var playerPos = player.position;
-                    var aimTarget = VirtualCamera.State.ReferenceLookAt;
-                    var dir = aimTarget - playerPos;
-                    if (RuntimeUtility.RaycastIgnoreTag(new Ray(playerPos, dir), 
-                            out RaycastHit hitInfo, dir.magnitude, AimCollisionFilter, IgnoreTag))
-                        aimTarget = hitInfo.point;
-                    AimTargetReticle.position = brain.OutputCamera.WorldToScreenPoint(aimTarget);
-                }
-            }
+            else if (AimTargetReticle != null)
+                AimTargetReticle.position = brain.OutputCamera.WorldToScreenPoint(AimTarget);
         }
 
-        Vector3 GetLookAtPoint(Vector3 camPos)
+        Vector3 ComputeLookAtPoint(Vector3 camPos, Transform player)
         {
-            var aimDistance = AimDistance;
-            var player = VirtualCamera.Follow;
-            
             // We don't want to hit targets behind the player
-            var fwd = Vector3.forward;
-            if (player != null)
+            var aimDistance = AimDistance;
+            var playerOrientation = player.rotation;
+            var fwd = playerOrientation * Vector3.forward;
+            var playerPos = Quaternion.Inverse(playerOrientation) * (player.position - camPos);
+            if (playerPos.z > 0)
             {
-                var playerOrientation = player.transform.rotation;
-                fwd = playerOrientation * Vector3.forward;
-                var playerPos = Quaternion.Inverse(playerOrientation) * (player.position - camPos);
-                if (playerPos.z > 0)
-                {
-                    camPos += fwd * playerPos.z;
-                    aimDistance -= playerPos.z;
-                }
+                camPos += fwd * playerPos.z;
+                aimDistance -= playerPos.z;
             }
 
             aimDistance = Mathf.Max(1, aimDistance);
             bool hasHit = RuntimeUtility.RaycastIgnoreTag(new Ray(camPos, fwd), 
                 out RaycastHit hitInfo, aimDistance, AimCollisionFilter, IgnoreTag);
             return hasHit ? hitInfo.point : camPos + fwd * aimDistance;
+        }
+        
+        Vector3 ComputeAimTarget(Vector3 cameraLookAt, Transform player)
+        {
+            // Adjust for actual player aim target (may be different due to offset)
+            var playerPos = player.position;
+            var dir = cameraLookAt - playerPos;
+            if (RuntimeUtility.RaycastIgnoreTag(new Ray(playerPos, dir), 
+                out RaycastHit hitInfo, dir.magnitude, AimCollisionFilter, IgnoreTag))
+                return hitInfo.point;
+            return cameraLookAt;
         }
         
         /// <summary>
@@ -131,10 +128,16 @@ namespace Cinemachine
             if (stage == CinemachineCore.Stage.Body)
             {
                 // Raycast to establish what we're actually aiming at
-                state.ReferenceLookAt = GetLookAtPoint(state.CorrectedPosition);
+                var player = vcam.Follow;
+                if (player != null)
+                {
+                    state.ReferenceLookAt = ComputeLookAtPoint(state.CorrectedPosition, player);
+                    AimTarget = ComputeAimTarget(state.ReferenceLookAt, player);
+                }
             }
             if (stage == CinemachineCore.Stage.Finalize)
             {
+                // Stabilize the LookAt point in the center of the screen
                 var dir = state.ReferenceLookAt - state.FinalPosition;
                 if (dir.sqrMagnitude > 0.01f)
                 {


### PR DESCRIPTION
* Expose AimTarget from 3rdPersonAim. ReferenceLookAt is unchanged.

* Changelog

* doc cleanup

* AimTarget is calculated even if there is no recticle added. + moved aim target logic to a separate function

* cleanup

Co-authored-by: Greg Labute <gregoryl@unity3d.com>

[Delete any line or section that does not apply]

### Purpose of this PR

[JIRA issue. Desc of feature/change. Links to screenshots, design docs, user docs, etc. Remember reviewers may be outside your team, and not know your feature/area that should be explained more.]

### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [ ] Added an automated test
- [ ] Passed all automated tests
- [ ] Manually tested 

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Samples status

- [ ] Re-packed Extras~/CinemachineExamples.unitypackage

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [ ] Updated package version
