### PR TITLE
CMCL-851: InputProvider correctly tracks enabled state of actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Bugfix: EmbeddedAssetProperties were not displayed correctly in the editor.
 - Timeline guards added to scripts that rely on it.
 - Bugfix: SaveDuringPlay works with ILists now.
+- Bugfix: CinemachineInputProvider now correctly tracks enabled state of input action
+
 
 ## [2.9.0-pre.6] - 2022-01-12
 - Bugfix: Negative Near Clip Plane value is kept when camera is orthographic.

--- a/Runtime/Helpers/CinemachineInputProvider.cs
+++ b/Runtime/Helpers/CinemachineInputProvider.cs
@@ -90,9 +90,14 @@ namespace Cinemachine
                     m_cachedActions[axis] = GetFirstMatch(InputUser.all[PlayerIndex], actionRef);
                 }
             }
-            // Auto-enable it if disabled
-            if (m_cachedActions[axis] != null && !m_cachedActions[axis].enabled)
-                m_cachedActions[axis].Enable();
+            // Update enabled status
+            if (m_cachedActions[axis] != null && m_cachedActions[axis].enabled != actionRef.action.enabled)
+            {
+                if (actionRef.action.enabled)
+                    m_cachedActions[axis].Enable();
+                else
+                    m_cachedActions[axis].Disable();
+            }
             
             return m_cachedActions[axis];
             


### PR DESCRIPTION
### Purpose of this PR

CMCL-851: InputProvider correctly tracks enabled state of actions

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

### Comment to reviewers:

Useful script to toggle enabled status of actions.  Add to an empty GameObject that you can then enable/disable to test.

```using System.Collections;
using System.Collections.Generic;
using UnityEngine;
using UnityEngine.InputSystem;

public class InputEnable : MonoBehaviour
{
    public List<InputActionReference> Actions = new List<InputActionReference>();

    private void OnEnable()
    {
        for (int i = 0; i < Actions.Count; ++i)
            if (Actions[i] != null)
                Actions[i].action.Enable();
    }

    private void OnDisable()
    {
        for (int i = 0; i < Actions.Count; ++i)
            if (Actions[i] != null)
                Actions[i].action.Disable();
    }
}
```