### PR TITLE
CMCL-0000: warn user of multiple components of the same pipeline

### DIFF
--- a/com.unity.cinemachine/Runtime/Experimental/CmCamera.cs
+++ b/com.unity.cinemachine/Runtime/Experimental/CmCamera.cs
@@ -307,7 +307,13 @@ namespace Cinemachine
                 m_Pipeline = new CinemachineComponentBase[Enum.GetValues(typeof(CinemachineCore.Stage)).Length];
                 var components = GetComponents<CinemachineComponentBase>();
                 for (int i = 0; i < components.Length; ++i)
+                {
+#if UNITY_EDITOR
+                    if (m_Pipeline[(int)components[i].Stage] != null)
+                        Debug.LogWarning("Multiple " + components[i].Stage + " components on " + name);
+#endif
                     m_Pipeline[(int)components[i].Stage] = components[i];
+                }
             }
         }
 


### PR DESCRIPTION
### Purpose of this PR
Editor-only warning message for user when they add more components of the same pipeline to a cm camera.
 
### Testing status
- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 