### PR TITLE
CMCL-1335: Fix priority comparison overflow bug - backport 2.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 - Bugfix: StateDrivenCamera/Clearshot: Transition glitch when backing out of a transition in progress.
+- Bugfix: priority ordering was wrong when the difference between any priority values were smaller than integer min or bigger than integer max values.
 - Bugfix: Transposer with LockToTarget binding sometimes had gimbal lock.
 - Bugfix: Collider damping is more robust with extreme FreeLook configurations.
 - Bugfix: AxisState Recentering wait time not work reliably in FixedUpdate.

--- a/Runtime/Core/CinemachineCore.cs
+++ b/Runtime/Core/CinemachineCore.cs
@@ -176,7 +176,7 @@ namespace Cinemachine
             if (!m_ActiveCamerasAreSorted && mActiveCameras.Count > 1)
             {
                 mActiveCameras.Sort((x, y) => 
-                    x.Priority == y.Priority ? y.m_ActivationId - x.m_ActivationId : y.Priority - x.Priority);
+                    x.Priority == y.Priority ? y.m_ActivationId.CompareTo(x.m_ActivationId) : y.Priority.CompareTo(x.Priority));
                 m_ActiveCamerasAreSorted = true;
             }
             return mActiveCameras[index];


### PR DESCRIPTION
### Purpose of this PR
Backport of https://github.com/Unity-Technologies/com.unity.cinemachine/pull/722.

### Testing status
- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested 

### Documentation status
- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation