### PR TITLE
CMCL-0000: Add pooling to tps sample

### DIFF
--- a/com.unity.cinemachine/Samples~/3D Samples.meta
+++ b/com.unity.cinemachine/Samples~/3D Samples.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b3b631701960b4ffa9d7a96890bdf47f
+guid: 8df9c796287304993be83d53afc4c62d
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/com.unity.cinemachine/Samples~/3D Samples/ThirdPerson Shooter.unity
+++ b/com.unity.cinemachine/Samples~/3D Samples/ThirdPerson Shooter.unity
@@ -1037,6 +1037,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
+      - m_Target: {fileID: 1802572052}
+        m_TargetAssemblyTypeName: Cinemachine.Examples.SimplePlayerController, Assembly-CSharp
+        m_MethodName: EnableLockCursor
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
 --- !u!4 &1040083249
 Transform:
   m_ObjectHideFlags: 0
@@ -2376,6 +2388,17 @@ Animator:
   m_CorrespondingSourceObject: {fileID: 7887234737240387235, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
   m_PrefabInstance: {fileID: 1802572047}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1802572052 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 8077383552022060413, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+  m_PrefabInstance: {fileID: 1802572047}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 297aaca66939f724fbbc8f0c485168bc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!114 &1802572053 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 7804758404662293724, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}

--- a/com.unity.cinemachine/Samples~/3D Samples/ThirdPerson Shooter.unity
+++ b/com.unity.cinemachine/Samples~/3D Samples/ThirdPerson Shooter.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748172, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1078,19 +1078,19 @@ PrefabInstance:
       objectReference: {fileID: 1802572048}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.9823122
+      value: -0.98231214
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.00000012665988
+      value: -0.00000011920929
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.18725069
+      value: -0.18725072
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.00000005960465
+      value: -0.000000059604645
       objectReference: {fileID: 0}
     - target: {fileID: 358930478696116476, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_RootOrder
@@ -1422,7 +1422,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b9a98e5e4b17784592b9725e8cfc063, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  BulletPrefab: {fileID: 3056719325741855433, guid: 31d678dfd458ff84d95d644dd3730cca, type: 3}
+  BulletPrefab: {fileID: 7562889651135581609, guid: 31d678dfd458ff84d95d644dd3730cca, type: 3}
   MaxBulletsPerSec: 10
   BulletSpeed: 500
   TimeInAir: 3
@@ -1677,7 +1677,7 @@ PrefabInstance:
       objectReference: {fileID: 1802572048}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.97614825
+      value: -0.9761483
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.x
@@ -1685,11 +1685,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.2171049
+      value: -0.21710493
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.000000029802319
+      value: -0
       objectReference: {fileID: 0}
     - target: {fileID: 358930478696116476, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_RootOrder
@@ -2415,15 +2415,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.00000028684732
+      value: -0.00000002235174
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.066447966
+      value: -0.06644798
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.000000029802319
+      value: 0.000000029802319
       objectReference: {fileID: 0}
     - target: {fileID: 358930478696116476, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_RootOrder

--- a/com.unity.cinemachine/Samples~/3D Samples/ThirdPerson Shooter.unity
+++ b/com.unity.cinemachine/Samples~/3D Samples/ThirdPerson Shooter.unity
@@ -38,7 +38,7 @@ RenderSettings:
   m_ReflectionIntensity: 1
   m_CustomReflection: {fileID: 0}
   m_Sun: {fileID: 0}
-  m_IndirectSpecularColor: {r: 0.44657874, g: 0.49641275, b: 0.5748172, a: 1}
+  m_IndirectSpecularColor: {r: 0.44657898, g: 0.4964133, b: 0.5748178, a: 1}
   m_UseRadianceAmbientProbe: 0
 --- !u!157 &3
 LightmapSettings:
@@ -1025,17 +1025,17 @@ MonoBehaviour:
   OnHelpDismissed:
     m_PersistentCalls:
       m_Calls:
-      - m_Target: {fileID: 1802572052}
-        m_TargetAssemblyTypeName: Cinemachine.Examples.SimplePlayerController, Assembly-CSharp
-        m_MethodName: EnableLockCursor
-        m_Mode: 1
+      - m_Target: {fileID: 1802572053}
+        m_TargetAssemblyTypeName: UnityEngine.Behaviour, UnityEngine
+        m_MethodName: set_enabled
+        m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
           m_IntArgument: 0
           m_FloatArgument: 0
           m_StringArgument: 
-          m_BoolArgument: 0
+          m_BoolArgument: 1
         m_CallState: 2
 --- !u!4 &1040083249
 Transform:
@@ -1078,19 +1078,19 @@ PrefabInstance:
       objectReference: {fileID: 1802572048}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.98231214
+      value: -0.9823122
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.00000011920929
+      value: -0.00000012665988
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.18725072
+      value: -0.18725069
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0.000000059604645
+      value: 0.00000005960465
       objectReference: {fileID: 0}
     - target: {fileID: 358930478696116476, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_RootOrder
@@ -1422,10 +1422,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 8b9a98e5e4b17784592b9725e8cfc063, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  BulletPrefab: {fileID: 7562889651135581609, guid: 31d678dfd458ff84d95d644dd3730cca, type: 3}
-  MaxBulletsPerSec: 10
-  BulletSpeed: 500
-  TimeInAir: 3
+  BulletPrefab: {fileID: 3056719325741855433, guid: 31d678dfd458ff84d95d644dd3730cca, type: 3}
+  MaxBulletsPerSec: 6
   PlayerRotationTime: 0.2
   Fire:
     Value: 0
@@ -1677,7 +1675,7 @@ PrefabInstance:
       objectReference: {fileID: 1802572048}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.w
-      value: -0.9761483
+      value: -0.97614825
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.x
@@ -1685,11 +1683,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.21710493
+      value: -0.2171049
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.z
-      value: -0
+      value: -0.000000029802319
       objectReference: {fileID: 0}
     - target: {fileID: 358930478696116476, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_RootOrder
@@ -2011,6 +2009,10 @@ PrefabInstance:
     - target: {fileID: 4417643423713582276, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
       propertyPath: Controllers.Array.data[6].Recentering.Enabled
       value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7804758404662293724, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+      propertyPath: m_Enabled
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 7804758404662293724, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
       propertyPath: Controllers.Array.size
@@ -2374,15 +2376,15 @@ Animator:
   m_CorrespondingSourceObject: {fileID: 7887234737240387235, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
   m_PrefabInstance: {fileID: 1802572047}
   m_PrefabAsset: {fileID: 0}
---- !u!114 &1802572052 stripped
+--- !u!114 &1802572053 stripped
 MonoBehaviour:
-  m_CorrespondingSourceObject: {fileID: 8077383552022060413, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
+  m_CorrespondingSourceObject: {fileID: 7804758404662293724, guid: 4d8d7a9a98d3f4ac2967d48094ea010f, type: 3}
   m_PrefabInstance: {fileID: 1802572047}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 0}
-  m_Enabled: 1
+  m_Enabled: 0
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 297aaca66939f724fbbc8f0c485168bc, type: 3}
+  m_Script: {fileID: 11500000, guid: 89875cdc57c54474a8a74efd9b2a3b5d, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!1001 &1972898889
@@ -2415,15 +2417,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.x
-      value: -0.00000002235174
+      value: -0.00000028684732
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0.06644798
+      value: -0.066447966
       objectReference: {fileID: 0}
     - target: {fileID: 358930478127896550, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_LocalRotation.z
-      value: 0.000000029802319
+      value: -0.000000029802319
       objectReference: {fileID: 0}
     - target: {fileID: 358930478696116476, guid: a93965bc906a245c49b8905bf8b48fec, type: 3}
       propertyPath: m_RootOrder

--- a/com.unity.cinemachine/Samples~/Shared Assets.meta
+++ b/com.unity.cinemachine/Samples~/Shared Assets.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: f6a503fd01bcc4ebab716892c7173d13
+guid: 377b17df8d2f04e5faeda826f1e52639
 folderAsset: yes
 DefaultImporter:
   externalObjects: {}

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimpleBullet.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimpleBullet.cs
@@ -6,34 +6,42 @@ namespace Cinemachine.Examples
     public class SimpleBullet : MonoBehaviour
     {
         public LayerMask CollisionLayers = 1;
+        public float Speed = 500;
+        public float Lifespan = 3;
 
-        Vector3 m_Direction;
         float m_Speed;
 
-        public void Fire(Vector3 direction, float speed, float lifespan)
+        void OnValidate()
         {
-            m_Direction = direction.normalized;
-            m_Speed = speed;
-            gameObject.SetActive(true);
-            StartCoroutine(Lifespan(lifespan));
+            Speed = Mathf.Max(1, Speed);
+            Lifespan = Mathf.Max(0.2f, Lifespan);
+        }
+
+        public void OnEnable()
+        {
+            m_Speed = Speed;
+            StartCoroutine(DeactivateAfter());
         }
 
         void Update()
         {
-            var t = transform;
-            if (Physics.Raycast(
-                t.position, m_Direction, out var hitInfo, m_Speed * Time.deltaTime, CollisionLayers,
-                QueryTriggerInteraction.Ignore))
+            if (m_Speed > 0)
             {
-                t.position = hitInfo.point;
-                m_Speed = 0;
+                var t = transform;
+                if (Physics.Raycast(
+                    t.position, t.forward, out var hitInfo, m_Speed * Time.deltaTime, CollisionLayers,
+                    QueryTriggerInteraction.Ignore))
+                {
+                    t.position = hitInfo.point;
+                    m_Speed = 0;
+                }
+                t.position += m_Speed * Time.deltaTime * t.forward;
             }
-            t.position += m_Direction * m_Speed * Time.deltaTime;
         }
         
-        IEnumerator Lifespan(float time)
+        IEnumerator DeactivateAfter()
         {
-            yield return new WaitForSeconds(time);
+            yield return new WaitForSeconds(Lifespan);
             gameObject.SetActive(false);
         }
     }

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimpleBullet.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimpleBullet.cs
@@ -1,3 +1,4 @@
+using System.Collections;
 using UnityEngine;
 
 namespace Cinemachine.Examples
@@ -9,10 +10,12 @@ namespace Cinemachine.Examples
         Vector3 m_Direction;
         float m_Speed;
 
-        public void Fire(Vector3 direction, float speed) 
+        public void Fire(Vector3 direction, float speed, float lifespan)
         {
             m_Direction = direction.normalized;
             m_Speed = speed;
+            gameObject.SetActive(true);
+            StartCoroutine(Lifespan(lifespan));
         }
 
         void Update()
@@ -26,6 +29,12 @@ namespace Cinemachine.Examples
                 m_Speed = 0;
             }
             t.position += m_Direction * m_Speed * Time.deltaTime;
+        }
+        
+        IEnumerator Lifespan(float time)
+        {
+            yield return new WaitForSeconds(time);
+            gameObject.SetActive(false);
         }
     }
 }

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/SimplePlayerController.cs
@@ -59,8 +59,7 @@ namespace Cinemachine.Examples
         public bool IsJumping => m_IsJumping;
         public bool IsMoving => m_LastInput.sqrMagnitude > 0.01f;
 
-        public void EnableLockCursor() => LockCursor = true;
-        public void DisableLockCursor() => LockCursor = false;
+        public void EnableLockCursor(bool enable) => LockCursor = enable;
 
         /// Report the available input axes to the input axis controller.
         /// We use the Input Axis Controller because it works with both the Input package


### PR DESCRIPTION
### Purpose of this PR

Add object pooling to tps sample to avoid unnecessary GC therefore allowing someone to take our code as is without needing optimizations.

Also added some quick optimization to avoid casting on null checks.

![Feb-09-2023 14-49-52](https://user-images.githubusercontent.com/10277745/217921983-70243fe6-52af-4eef-856d-b9586c4ff8c9.gif)

Instead of destroying older bullets it disable them and enables them once you fire. Allowing to avoid destroying and instantiating new one every time.

### Testing status

Opened the ThirdPerson Shooter sample and made sure it was working the same. 

### Technical risk

Low sample change.

### Comments to reviewers

I really would like to have this code in the samples. Wether we use it or not in the TPS project or just as a low end device friendly alternative or a commented section in the original code. Instantiating and Destroying can have a big impact on performances.
