### PR TITLE
CMCL-1650: Add support for calling ManualUpdate multiple times per frame

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
  
 ### Added
 - Added Easing setting to FreeLookModifier, to smooth the transition between top and bottom FreeLook hemispheres.
+- Added an overload for `CinemachineBrain.ManualUpdate` which takes a custom frame count and deltaTime, allowing more customized control over the game loop.
 
 
 ## [3.1.3] - 2025-02-01

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -579,8 +579,7 @@ namespace Unity.Cinemachine
 
         void DoNonFixedUpdate(int updateFrame)
         {
-            m_LastFrameUpdated = CinemachineCore.CurrentUpdateFrame;
-            CinemachineCore.CurrentUpdateFrame = updateFrame;
+            m_LastFrameUpdated = CinemachineCore.CurrentUpdateFrame = updateFrame;
 
             float deltaTime = GetEffectiveDeltaTime(false);
             if (Application.isPlaying && (UpdateMethod == UpdateMethods.FixedUpdate || Time.inFixedTimeStep))

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineBrain.cs
@@ -241,20 +241,22 @@ namespace Unity.Cinemachine
 
         void OnSceneLoaded(Scene scene, LoadSceneMode mode)
         {
-            if (Time.frameCount == m_LastFrameUpdated && m_BlendManager.IsInitialized)
-                ManualUpdate();
+            if (Time.frameCount == m_LastFrameUpdated 
+                    && m_BlendManager.IsInitialized && UpdateMethod != UpdateMethods.ManualUpdate)
+                DoNonFixedUpdate(Time.frameCount);
         }
 
         void OnSceneUnloaded(Scene scene)
         {
-            if (Time.frameCount == m_LastFrameUpdated && m_BlendManager.IsInitialized)
-                ManualUpdate();
+            if (Time.frameCount == m_LastFrameUpdated 
+                    && m_BlendManager.IsInitialized && UpdateMethod != UpdateMethods.ManualUpdate)
+                DoNonFixedUpdate(Time.frameCount);
         }
 
         void LateUpdate()
         {
             if (UpdateMethod != UpdateMethods.ManualUpdate)
-                ManualUpdate();
+                DoNonFixedUpdate(Time.frameCount);
         }
 
         // Instead of FixedUpdate() we have this, to ensure that it happens
@@ -517,20 +519,68 @@ namespace Unity.Cinemachine
 
         /// <summary>
         /// Updates CinemachineCameras and positions the main camera when UpdateMode is set to ManualUpdate.
-        /// This method should only be called externally in ManualUpdate mode. For other modes, updates occur 
+        /// This method should only be called in ManualUpdate mode. For other modes, updates occur 
+        /// automatically and this method should not be called explicitly.
+        /// </summary>
+        /// <param name="currentFrame">The current update frmae.  This is a substiture for Time.frameCount.  
+        /// If you're controlling your own player loop and timestep, this parameter indicates the current frame.  
+        /// Each call should increwase this number by 1.</param>
+        /// <param name="deltaTime">The game time that elapsed since the last call to this method.  A value of -1 will 
+        /// cancel previous frame state, effectively cancelling damping and making the CInemachineCameras snap to position.</param>
+        /// <remarks>
+        /// Important usage notes:
+        /// <list type="bullet">
+        /// <item>Never call this method from FixedUpdate.</item>
+        /// <item>This version of the method allows you to explicitly control the update frame count and the deltaTime.</item>
+        /// <item>This method must be called exactly once per update frame - more frequent calls 
+        /// will not update the cameras, and less frequent calls may cause jerky camera movement.</item>
+        /// </list>
+        /// </remarks>
+        public void ManualUpdate(int currentFrame, float deltaTime)
+        {
+#if UNITY_EDITOR
+            if (UpdateMethod != UpdateMethods.ManualUpdate)
+                Debug.LogError("CinemachineBrain.ManualUpdate was called but CinemachineBrain is not in ManualUpdate mode");
+            if (Time.inFixedTimeStep)
+                Debug.LogError("CinemachineBrain.ManualUpdate was called from FixedUpdate");
+#endif
+            var prev = CinemachineCore.UniformDeltaTimeOverride;
+            CinemachineCore.UniformDeltaTimeOverride = deltaTime;
+            DoNonFixedUpdate(currentFrame);
+            CinemachineCore.UniformDeltaTimeOverride = prev;
+        }
+
+        /// <summary>
+        /// Updates CinemachineCameras and positions the main camera when UpdateMode is set to ManualUpdate.
+        /// This method should only be called in ManualUpdate mode. For other modes, updates occur 
         /// automatically and this method should not be called explicitly.
         /// </summary>
         /// <remarks>
         /// Important usage notes:
         /// <list type="bullet">
-        /// <item>Only call this method from Update or LateUpdate, never from FixedUpdate.</item>
+        /// <item>Never call this method from FixedUpdate.</item>
         /// <item>This method must be called exactly once per render frame - more frequent calls 
         /// will not update the cameras, and less frequent calls may cause jerky camera movement.</item>
+        /// <item>This version of the method will automatically track the update frame count and the current delta time.  
+        /// If you want to explicitylt control deltaTime and update frame count, use the version of this method that 
+        /// allows you to specify those values.</item>
         /// </list>
         /// </remarks>
         public void ManualUpdate()
         {
-            m_LastFrameUpdated = Time.frameCount;
+#if UNITY_EDITOR
+            if (UpdateMethod != UpdateMethods.ManualUpdate)
+                Debug.LogError("CinemachineBrain.ManualUpdate was called but CinemachineBrain is not in ManualUpdate mode");
+            if (Time.inFixedTimeStep)
+                Debug.LogError("CinemachineBrain.ManualUpdate was called from FixedUpdate");
+#endif
+            DoNonFixedUpdate(Time.frameCount);
+        }
+
+        void DoNonFixedUpdate(int updateFrame)
+        {
+            m_LastFrameUpdated = CinemachineCore.CurrentUpdateFrame;
+            CinemachineCore.CurrentUpdateFrame = updateFrame;
 
             float deltaTime = GetEffectiveDeltaTime(false);
             if (Application.isPlaying && (UpdateMethod == UpdateMethods.FixedUpdate || Time.inFixedTimeStep))

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineTargetGroup.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineTargetGroup.cs
@@ -208,7 +208,7 @@ namespace Unity.Cinemachine
         {
             get
             {
-                if (m_LastUpdateFrame != Time.frameCount)
+                if (m_LastUpdateFrame != CinemachineCore.CurrentUpdateFrame)
                     DoUpdate();
                 return m_BoundingBox;
             }
@@ -221,7 +221,7 @@ namespace Unity.Cinemachine
         {
             get
             {
-                if (m_LastUpdateFrame != Time.frameCount)
+                if (m_LastUpdateFrame != CinemachineCore.CurrentUpdateFrame)
                     DoUpdate();
                 return m_BoundingSphere;
             }
@@ -236,7 +236,7 @@ namespace Unity.Cinemachine
         {
             get
             {
-                if (m_LastUpdateFrame != Time.frameCount)
+                if (m_LastUpdateFrame != CinemachineCore.CurrentUpdateFrame)
                     DoUpdate();
                 return m_ValidMembers.Count == 0;
             }
@@ -283,7 +283,7 @@ namespace Unity.Cinemachine
         /// <returns>The weighted bounding sphere</returns>
         public BoundingSphere GetWeightedBoundsForMember(int index)
         {
-            if (m_LastUpdateFrame != Time.frameCount)
+            if (m_LastUpdateFrame != CinemachineCore.CurrentUpdateFrame)
                 DoUpdate();
             if (!IndexIsValid(index) || !m_MemberValidity[index])
                 return Sphere;
@@ -299,7 +299,7 @@ namespace Unity.Cinemachine
         /// <returns>The axis-aligned bounding box of the group, in the desired frame of reference</returns>
         public Bounds GetViewSpaceBoundingBox(Matrix4x4 observer, bool includeBehind)
         {
-            if (m_LastUpdateFrame != Time.frameCount)
+            if (m_LastUpdateFrame != CinemachineCore.CurrentUpdateFrame)
                 DoUpdate();
             var inverseView = observer;
             if (!Matrix4x4.Inverse3DAffine(observer, ref inverseView))
@@ -347,7 +347,7 @@ namespace Unity.Cinemachine
         /// </summary>
         public void DoUpdate()
         {
-            m_LastUpdateFrame = Time.frameCount;
+            m_LastUpdateFrame = CinemachineCore.CurrentUpdateFrame;
 
             UpdateMemberValidity();
             m_AveragePos = CalculateAveragePosition();
@@ -511,7 +511,7 @@ namespace Unity.Cinemachine
         public void GetViewSpaceAngularBounds(
             Matrix4x4 observer, out Vector2 minAngles, out Vector2 maxAngles, out Vector2 zRange)
         {
-            if (m_LastUpdateFrame != Time.frameCount)
+            if (m_LastUpdateFrame != CinemachineCore.CurrentUpdateFrame)
                 DoUpdate();
             var world2local = observer;
             if (!Matrix4x4.Inverse3DAffine(observer, ref world2local))

--- a/com.unity.cinemachine/Runtime/Core/CameraUpdateManager.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraUpdateManager.cs
@@ -176,14 +176,14 @@ namespace Unity.Cinemachine
                 status = new UpdateStatus
                 {
                     lastUpdateMode = UpdateTracker.UpdateClock.Late,
-                    lastUpdateFrame = Time.frameCount + 2, // so that frameDelta ends up negative
+                    lastUpdateFrame = CinemachineCore.CurrentUpdateFrame + 2, // so that frameDelta ends up negative
                     lastUpdateFixedFrame = s_FixedFrameCount + 2
                 };
                 s_UpdateStatus.Add(vcam, status);
             }
 
             int frameDelta = (updateClock == UpdateTracker.UpdateClock.Late)
-                ? Time.frameCount - status.lastUpdateFrame
+                ? CinemachineCore.CurrentUpdateFrame - status.lastUpdateFrame
                 : s_FixedFrameCount - status.lastUpdateFixedFrame;
 
             if (deltaTime >= 0)
@@ -194,9 +194,9 @@ namespace Unity.Cinemachine
                     deltaTime *= frameDelta; // try to catch up if multiple frames
             }
 
-//Debug.Log((vcam.ParentCamera == null ? "" : vcam.ParentCamera.Name + ".") + vcam.Name + ": frame " + Time.frameCount + "/" + status.lastUpdateFixedFrame + ", " + s_CurrentUpdateFilter + ", deltaTime = " + deltaTime);
+//Debug.Log((vcam.ParentCamera == null ? "" : vcam.ParentCamera.Name + ".") + vcam.Name + ": frame " + CinemachineCore.CurrentUpdateFrame + "/" + status.lastUpdateFixedFrame + ", " + s_CurrentUpdateFilter + ", deltaTime = " + deltaTime);
             vcam.InternalUpdateCameraState(worldUp, deltaTime);
-            status.lastUpdateFrame = Time.frameCount;
+            status.lastUpdateFrame = CinemachineCore.CurrentUpdateFrame;
             status.lastUpdateFixedFrame = s_FixedFrameCount;
             status.lastUpdateMode = updateClock;
         }

--- a/com.unity.cinemachine/Runtime/Core/CinemachineCore.cs
+++ b/com.unity.cinemachine/Runtime/Core/CinemachineCore.cs
@@ -135,6 +135,13 @@ namespace Unity.Cinemachine
         public static float CurrentTime => CurrentTimeOverride >= 0 ? CurrentTimeOverride : Time.time;
 
         /// <summary>
+        /// The current frame
+        /// By default this is Time.frameCount.  If you are using ManualUpdate with a custom update frame, 
+        /// then this value will reflect the custom framed passed to ManualUpdate().
+        /// </summary>
+        public static int CurrentUpdateFrame { get; internal set; }
+
+        /// <summary>
         /// Delegate for overriding a blend that is about to be applied to a transition.
         /// A handler can either return the default blend, or a new blend definition
         /// specific to current conditions.

--- a/com.unity.cinemachine/Runtime/Deprecated/AxisState.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/AxisState.cs
@@ -216,9 +216,9 @@ namespace Unity.Cinemachine
         public bool Update(float deltaTime)
         {
             // Update only once per frame
-            if (Time.frameCount == m_LastUpdateFrame)
+            if (CinemachineCore.CurrentUpdateFrame == m_LastUpdateFrame)
                 return false;
-            m_LastUpdateFrame = Time.frameCount;
+            m_LastUpdateFrame = CinemachineCore.CurrentUpdateFrame;
 
             // Cheating: we want the render frame time, not the fixed frame time
             if (deltaTime > 0 && m_LastUpdateTime != 0)

--- a/com.unity.cinemachine/Runtime/Deprecated/CinemachineFreeLook.cs
+++ b/com.unity.cinemachine/Runtime/Deprecated/CinemachineFreeLook.cs
@@ -792,9 +792,9 @@ namespace Unity.Cinemachine
                 return 0; // deleted
 
             // Update the axis only once per frame
-            if (m_LastHeadingUpdateFrame != Time.frameCount)
+            if (m_LastHeadingUpdateFrame != CinemachineCore.CurrentUpdateFrame)
             {
-                m_LastHeadingUpdateFrame = Time.frameCount;
+                m_LastHeadingUpdateFrame = CinemachineCore.CurrentUpdateFrame;
                 var oldValue = m_XAxis.Value;
                 m_CachedXAxisHeading = orbital.UpdateHeading(
                     PreviousStateIsValid ? deltaTime : -1, up,

--- a/com.unity.cinemachine/Tests/Runtime/CamerasBlendingTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/CamerasBlendingTests.cs
@@ -21,13 +21,8 @@ namespace Unity.Cinemachine.Tests
             m_Brain.DefaultBlend =
                 new CinemachineBlendDefinition(CinemachineBlendDefinition.Styles.Linear, k_BlendingTime);
 
-#if CINEMACHINE_V3_OR_HIGHER
             m_Source = CreateGameObject("A", typeof(CinemachineCamera)).GetComponent<CinemachineCamera>();
             m_Target = CreateGameObject("B", typeof(CinemachineCamera)).GetComponent<CinemachineCamera>();
-#else
-            m_Source = CreateGameObject("A", typeof(CinemachineVirtualCamera)).GetComponent<CinemachineVirtualCamera>();
-            m_Target = CreateGameObject("B", typeof(CinemachineVirtualCamera)).GetComponent<CinemachineVirtualCamera>();
-#endif
             m_Source.Priority.Value = 10;
             m_Target.Priority.Value = 15;
             m_Source.enabled = true;

--- a/com.unity.cinemachine/Tests/Runtime/CinemachineBrainSetupTest.cs
+++ b/com.unity.cinemachine/Tests/Runtime/CinemachineBrainSetupTest.cs
@@ -14,7 +14,7 @@ namespace Unity.Cinemachine.Tests
         GameObject m_FollowObject;
 
         [SetUp]
-        public void Setup()
+        public override void SetUp()
         {
             base.SetUp();
             CreateGameObject("Brain", typeof(CinemachineBrain));

--- a/com.unity.cinemachine/Tests/Runtime/CinemachineRuntimeTimeInvariantFixtureBase.cs
+++ b/com.unity.cinemachine/Tests/Runtime/CinemachineRuntimeTimeInvariantFixtureBase.cs
@@ -30,7 +30,7 @@ namespace Unity.Cinemachine.Tests
         }
 
         /// <summary>Triggers manual update, increments cinemachine time, and waits one frame</summary>
-        protected IEnumerator UpdateCinemachine()
+        virtual protected IEnumerator UpdateCinemachine()
         {
             m_Brain.ManualUpdate();
             CinemachineCore.CurrentTimeOverride += CinemachineCore.UniformDeltaTimeOverride;

--- a/com.unity.cinemachine/Tests/Runtime/ManualUpdateTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/ManualUpdateTests.cs
@@ -31,7 +31,8 @@ namespace Unity.Cinemachine.Tests
         public IEnumerator ManualUpdateRespectsFrameCount()
         {
             // Check that source vcam is active
-            yield return UpdateCinemachine();
+            int currentFrame = 0;
+            yield return UpdateCinemachine(currentFrame++);
             Assert.That(ReferenceEquals(m_Brain.ActiveVirtualCamera, m_vcam));
 
             // Update should do something if we call it exactly once per frame
@@ -39,7 +40,7 @@ namespace Unity.Cinemachine.Tests
             for (int i = 0; i < 5; ++i)
             {
                 Assert.AreEqual(i, m_TestCounter.UpdateCount, "Single call to ManualUpdate per frame, update count does not match");
-                yield return UpdateCinemachine(i);
+                yield return UpdateCinemachine(currentFrame++);
             }
 
             // Multiple calls to ManualUpdate within the same frame should have no effect (other than to waste time)
@@ -47,8 +48,8 @@ namespace Unity.Cinemachine.Tests
             for (int i = 0; i < 5; ++i)
             {
                 Assert.AreEqual(i, m_TestCounter.UpdateCount, "Multiple calls to ManualUpdate per frame, update count does not match");
-                m_Brain.ManualUpdate(i, CinemachineCore.UniformDeltaTimeOverride); // spurious call to ManualUpdate
-                yield return UpdateCinemachine(i);
+                m_Brain.ManualUpdate(currentFrame, CinemachineCore.UniformDeltaTimeOverride); // spurious call to ManualUpdate
+                yield return UpdateCinemachine(currentFrame++);
             }
         }
     }

--- a/com.unity.cinemachine/Tests/Runtime/ManualUpdateTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/ManualUpdateTests.cs
@@ -1,0 +1,55 @@
+using System.Collections;
+using NUnit.Framework;
+using UnityEngine.TestTools;
+
+namespace Unity.Cinemachine.Tests
+{
+    [TestFixture]
+    public class ManualUpdateTests : CinemachineRuntimeTimeInvariantFixtureBase
+    {
+        CinemachineVirtualCameraBase m_vcam;
+        UpdateCounterForTests m_TestCounter;
+
+        /// <summary>Triggers manual update, increments cinemachine time, and waits one frame</summary>
+        virtual protected IEnumerator UpdateCinemachine(int frameCount)
+        {
+            m_Brain.ManualUpdate(frameCount, CinemachineCore.UniformDeltaTimeOverride);
+            CinemachineCore.CurrentTimeOverride += CinemachineCore.UniformDeltaTimeOverride;
+            CinemachineCore.CurrentUnscaledTimeTimeOverride += CinemachineCore.UniformDeltaTimeOverride;
+            yield return null;
+        }
+
+        [SetUp]
+        public override void SetUp()
+        {
+            base.SetUp();
+            m_vcam = CreateGameObject("vcam", typeof(CinemachineCamera)).GetComponent<CinemachineCamera>();
+            m_TestCounter = m_vcam.gameObject.AddComponent<UpdateCounterForTests>();
+        }
+
+        [UnityTest]
+        public IEnumerator ManualUpdateRespectsFrameCount()
+        {
+            // Check that source vcam is active
+            yield return UpdateCinemachine();
+            Assert.That(ReferenceEquals(m_Brain.ActiveVirtualCamera, m_vcam));
+
+            // Update should do something if we call it exactly once per frame
+            m_TestCounter.UpdateCount = 0;
+            for (int i = 0; i < 5; ++i)
+            {
+                Assert.AreEqual(m_TestCounter.UpdateCount, i);
+                yield return UpdateCinemachine(i);
+            }
+
+            // Multiple calls to ManualUpdate within the same frame should have no effect (other than to waste time)
+            m_TestCounter.UpdateCount = 0;
+            for (int i = 0; i < 5; ++i)
+            {
+                Assert.AreEqual(m_TestCounter.UpdateCount, i);
+                yield return UpdateCinemachine(i);
+                yield return UpdateCinemachine(i);
+            }
+        }
+    }
+}

--- a/com.unity.cinemachine/Tests/Runtime/ManualUpdateTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/ManualUpdateTests.cs
@@ -47,7 +47,7 @@ namespace Unity.Cinemachine.Tests
             for (int i = 0; i < 5; ++i)
             {
                 Assert.AreEqual(m_TestCounter.UpdateCount, i);
-                yield return UpdateCinemachine(i);
+                m_Brain.ManualUpdate(i, CinemachineCore.UniformDeltaTimeOverride); // spurious call to ManualUpdate
                 yield return UpdateCinemachine(i);
             }
         }

--- a/com.unity.cinemachine/Tests/Runtime/ManualUpdateTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/ManualUpdateTests.cs
@@ -1,11 +1,12 @@
 using System.Collections;
 using NUnit.Framework;
+using UnityEngine;
 using UnityEngine.TestTools;
 
 namespace Unity.Cinemachine.Tests
 {
     [TestFixture]
-    public class ManualUpdateTests : CinemachineRuntimeTimeInvariantFixtureBase
+    public class ManualUpdateTests : CinemachineRuntimeFixtureBase
     {
         CinemachineVirtualCameraBase m_vcam;
         UpdateCounterForTests m_TestCounter;
@@ -23,6 +24,7 @@ namespace Unity.Cinemachine.Tests
         public override void SetUp()
         {
             base.SetUp();
+            m_Brain.UpdateMethod = CinemachineBrain.UpdateMethods.ManualUpdate;
             m_vcam = CreateGameObject("vcam", typeof(CinemachineCamera)).GetComponent<CinemachineCamera>();
             m_TestCounter = m_vcam.gameObject.AddComponent<UpdateCounterForTests>();
         }

--- a/com.unity.cinemachine/Tests/Runtime/ManualUpdateTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/ManualUpdateTests.cs
@@ -38,7 +38,7 @@ namespace Unity.Cinemachine.Tests
             m_TestCounter.UpdateCount = 0;
             for (int i = 0; i < 5; ++i)
             {
-                Assert.AreEqual(m_TestCounter.UpdateCount, i);
+                Assert.AreEqual(i, m_TestCounter.UpdateCount, "Single call to ManualUpdate per frame, update count does not match");
                 yield return UpdateCinemachine(i);
             }
 
@@ -46,7 +46,7 @@ namespace Unity.Cinemachine.Tests
             m_TestCounter.UpdateCount = 0;
             for (int i = 0; i < 5; ++i)
             {
-                Assert.AreEqual(m_TestCounter.UpdateCount, i);
+                Assert.AreEqual(i, m_TestCounter.UpdateCount, "Multiple calls to ManualUpdate per frame, update count does not match");
                 m_Brain.ManualUpdate(i, CinemachineCore.UniformDeltaTimeOverride); // spurious call to ManualUpdate
                 yield return UpdateCinemachine(i);
             }

--- a/com.unity.cinemachine/Tests/Runtime/ManualUpdateTests.cs.meta
+++ b/com.unity.cinemachine/Tests/Runtime/ManualUpdateTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 64fdf67675f28474bbc8f8c0aa8e0bbc
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/com.unity.cinemachine/Tests/Runtime/SplineCartTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/SplineCartTests.cs
@@ -15,7 +15,7 @@ namespace Unity.Cinemachine.Tests
         SplineContainer m_SplineContainer;
 
         [SetUp]
-        public void Setup()
+        public override void SetUp()
         {
             base.SetUp();
 

--- a/com.unity.cinemachine/Tests/Runtime/SplineDollyCameraTest.cs
+++ b/com.unity.cinemachine/Tests/Runtime/SplineDollyCameraTest.cs
@@ -16,7 +16,7 @@ namespace Unity.Cinemachine.Tests
         SplineContainer m_SplineContainer;
 
         [SetUp]
-        public void Setup()
+        public override void SetUp()
         {
             base.SetUp();
 

--- a/com.unity.cinemachine/Tests/Runtime/SplineDollyLookatTarget.cs
+++ b/com.unity.cinemachine/Tests/Runtime/SplineDollyLookatTarget.cs
@@ -18,7 +18,7 @@ namespace Unity.Cinemachine.Tests
         Vector3 m_SecondLookAtPoint = new Vector3(-10, 0, -10);
 
         [SetUp]
-        public void Setup()
+        public override void SetUp()
         {
             base.SetUp();
 

--- a/com.unity.cinemachine/Tests/Runtime/Unity.Cinemachine.Runtime.Tests.asmdef
+++ b/com.unity.cinemachine/Tests/Runtime/Unity.Cinemachine.Runtime.Tests.asmdef
@@ -43,11 +43,6 @@
             "define": "CINEMACHINE_UNITY_SPLINES"
         },
         {
-            "name": "com.unity.cinemachine",
-            "expression": "3.0.0-pre.1",
-            "define": "CINEMACHINE_V3_OR_HIGHER"
-        },
-        {
             "name": "com.unity.render-pipelines.high-definition",
             "expression": "14.0.0",
             "define": "CINEMACHINE_HDRP"

--- a/com.unity.cinemachine/Tests/Runtime/UpdateCounterForTests.cs
+++ b/com.unity.cinemachine/Tests/Runtime/UpdateCounterForTests.cs
@@ -1,0 +1,20 @@
+using System.Collections;
+using System.Collections.Generic;
+using Unity.Cinemachine;
+using UnityEngine;
+
+namespace Unity.Cinemachine.Tests
+{
+    public class UpdateCounterForTests : CinemachineExtension
+    {
+        public int UpdateCount { get; set; }
+
+        protected override void PostPipelineStageCallback(
+            CinemachineVirtualCameraBase vcam,
+            CinemachineCore.Stage stage, ref CameraState state, float deltaTime) 
+        {
+            if (stage == CinemachineCore.Stage.Finalize)
+                ++UpdateCount;
+        }
+    }
+}

--- a/com.unity.cinemachine/Tests/Runtime/UpdateCounterForTests.cs.meta
+++ b/com.unity.cinemachine/Tests/Runtime/UpdateCounterForTests.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4f357241b4c0baf4285e1d950dd67a66
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Purpose of this PR

This is to support the rare use-case of someone implementing their own update loop (perhaps with ECS).  Let's say they use a fixed timestep which is not synchronized with the render frames (much the same way FixedUpdate works).

They want to call ManualUpdate once per custom frame.  Now they can do this, using the new CinemachineBrain.ManualUpdate() overload that takes a custom frameCount and a timestep.  The old entry point is still there, and continues to behave as before.

### Testing status

- [x] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

Low.  Old behaviour is untouched.  It's possible that the new path does not cover all the use cases, but it won't be a regression.

### Comments to reviewers

