### PR TITLE
CMCL-1694: Fix blend reversal logic and add unit test

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.1.5] - 2025-012-31
+### Unreleased
+
+### Bugfixes
+- Ensure that correct blend time is always used when backing out of a blend-in-progress.
+
+
 ## [3.1.4] - 2025-06-10
 
 ### Bugfixes

--- a/com.unity.cinemachine/package.json
+++ b/com.unity.cinemachine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.cinemachine",
   "displayName": "Cinemachine",
-  "version": "3.1.4",
+  "version": "3.1.5",
   "unity": "2022.3",
   "description": "Smart camera tools for passionate creators. \n\nCinemachine 3 is a newer and better version of Cinemachine, but upgrading an existing project from 2.X will likely require some effort.  If you're considering upgrading an older project, please see our upgrade guide in the user manual.",
   "keywords": [


### PR DESCRIPTION
### Purpose of this PR

Fixes CMCL-1694.  See ticket for a test project.

Improves the handling of reversing a blend-in-progress in CameraBlendStack by tracking the normalized blend position and adjusting the blend duration accordingly. Adds a comprehensive unit test in BlendManagerTests to verify correct behavior when repeatedly reversing blends between cameras.

### Testing status

- [x] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low


