### PR TITLE
CMCL-1706: Added InputAxisControllerBase.GetController() and InputAxisControllerBase.TriggerRecentering()

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ### Added
 - Added `CinemachineConfiner2D.CameraWasDisplaced()` and `CinemachineConfiner2D.GetCameraDisplacementDistance()` methods.
+- Added `InputAxisControllerBase.GetController()` method, to conveniently fetch an Input Controller having a specific name.
+- Added `InputAxisControllerBase.TriggerRecentering()` to trigger recentering of an axis having a specific name.
 
 
 ## [3.1.4] - 2025-06-10

--- a/com.unity.cinemachine/Runtime/Core/InputAxis.cs
+++ b/com.unity.cinemachine/Runtime/Core/InputAxis.cs
@@ -404,6 +404,7 @@ namespace Unity.Cinemachine
         /// Cancel any current input, resetting the speed to zero.  This will eliminate any 
         /// residual acceleration or deceleration of the input value.
         /// </summary>
+        /// <param name="axis">The axis in question</param>
         public void CancelCurrentInput(ref InputAxis axis)
         {
             m_CurrentSpeed = 0;

--- a/com.unity.cinemachine/Runtime/Core/InputAxis.cs
+++ b/com.unity.cinemachine/Runtime/Core/InputAxis.cs
@@ -303,8 +303,9 @@ namespace Unity.Cinemachine
             }
         }
 
-        /// <summary>Trigger re-centering immediately, regardless of whether re-centering
-        /// is enabled or the wait time has elapsed.</summary>
+        /// <summary>Trigger recentering immediately, regardless of whether recentering
+        /// is enabled or the wait time has elapsed.  Note that Recentering will be automatically canceled
+        /// if any change to the input value is detected.</summary>
         public void TriggerRecentering() => m_RecenteringState.m_ForceRecenter = true;
 
         /// <summary>Cancel any current re-centering in progress, and reset the wait time</summary>
@@ -397,6 +398,16 @@ namespace Unity.Cinemachine
         {
             m_CurrentSpeed = 0;
             axis.Reset();
+        }
+
+        /// <summary>
+        /// Cancel any current input, resetting the speed to zero.  This will eliminate any 
+        /// residual acceleration or deceleration of the input value.
+        /// </summary>
+        public void CancelCurrentInput(ref InputAxis axis)
+        {
+            m_CurrentSpeed = 0;
+            axis.SetValueAndLastValue(axis.Value);
         }
     }
 }

--- a/com.unity.cinemachine/Runtime/Core/InputAxisControllerBase.cs
+++ b/com.unity.cinemachine/Runtime/Core/InputAxisControllerBase.cs
@@ -195,8 +195,47 @@ namespace Unity.Cinemachine
                 c.Driver.ProcessInput(ref m_Axes[i].DrivenAxis(), c.InputValue, deltaTime);
             }
         }
-    }
 
+        int GetControllerIndex(string axisName)
+        {
+            for (int i = 0; i < Controllers.Count; ++i)
+            {
+                var c = Controllers[i];
+                if (c.Name == axisName)
+                    return i;
+            }
+            return -1;
+        }
+
+        /// <summary>
+        /// Get the controller for a given axis name.  The axis name is the name displayed 
+        /// for the axis foldout on the inspector.
+        /// </summary>
+        /// <param name="axisName">The name of the axis, as it appears in the inspector.</param>
+        /// <returns>The first Controller object with the matching axis name, or null if not found.</returns>
+        public InputAxisControllerBase<T>.Controller GetController(string axisName)
+        {
+            int i = GetControllerIndex(axisName);
+            return i < 0 ? null : Controllers[i];
+        }
+
+        /// <summary>
+        /// Triggers recentering for a given axis, and also cancels any input currently in progrress for that axis.
+        /// </summary>
+        /// <param name="axisName">The name of the axis, as it appears in the inspector.</param>
+        /// <returns>True if the axis was found and recentering triggered, false otherwise</returns>
+        public bool TriggerRecentering(string axisName)
+        {
+            int i = GetControllerIndex(axisName);
+            if (i >= 0)
+            {
+                var c = Controllers[i];
+                c.Driver.CancelCurrentInput(ref m_Axes[i].DrivenAxis());
+                m_Axes[i].DrivenAxis().TriggerRecentering();
+            }
+            return i >= 0;
+        }
+    }
 
     /// <summary>
     /// This is a base class for a behaviour that is used to drive IInputAxisOwner behaviours,
@@ -331,6 +370,22 @@ namespace Unity.Cinemachine
 
             m_ControllerManager.UpdateControllers(this, deltaTime);
         }
+        
+        /// <summary>
+        /// Get the controller for a given axis name.  The axis name is the name displayed 
+        /// for the axis foldout on the inspector.
+        /// </summary>
+        /// <param name="axisName">The name of the axis, as it appears in the inspector.</param>
+        /// <returns>The first Controller object with the matching axis name, or null if not found.</returns>
+        public Controller GetController(string axisName) => m_ControllerManager.GetController(axisName);
+
+        /// <summary>
+        /// Triggers recentering for a given axis, and also cancels any input currently in progress for that axis.
+        /// This ensures that the recentering begins immediately.
+        /// </summary>
+        /// <param name="axisName">The name of the axis, as it appears in the inspector.</param>
+        /// <returns>True if the axis was found and recentering triggered, false otherwise</returns>
+        public bool TriggerRecentering(string axisName) => m_ControllerManager.TriggerRecentering(axisName);
     }
 }
 


### PR DESCRIPTION
### Purpose of this PR

CMCL-1706: Reported on Discussions: 
https://discussions.unity.com/t/inputaxis-triggerrecentering-doesnt-animate/945363/9

The issue was that while recentering got triggered, lingering input from the InputAxisController decelerator would read as new user input, immediately causing the recentering to be halted.

The fix is to add a new method to InputAxisController, which both cancels the lingering input and triggers the recentering.

### Testing status

- [ ] Added an automated test
- [x] Passed all automated tests
- [x] Manually tested

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [x] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low - just added new API
