### PR TITLE
Add missing missing target warning on ThirdPersonFollow inspector

### DIFF
--- a/com.unity.cinemachine/Runtime/Components/CinemachineThirdPersonFollow.cs
+++ b/com.unity.cinemachine/Runtime/Components/CinemachineThirdPersonFollow.cs
@@ -11,6 +11,7 @@ namespace Unity.Cinemachine
     [SaveDuringPlay]
     [DisallowMultipleComponent]
     [CameraPipeline(CinemachineCore.Stage.Body)]
+    [RequiredTarget(RequiredTargetAttribute.RequiredTargets.Tracking)]
     [HelpURL(Documentation.BaseURL + "manual/CinemachineThirdPersonFollow.html")]
     public class CinemachineThirdPersonFollow : CinemachineComponentBase
         , CinemachineFreeLookModifier.IModifierValueSource


### PR DESCRIPTION
### Purpose of this PR

CMCL-1715: Missing inspector warning on ThirdPersonFollow

<img width="337" height="371" alt="image" src="https://github.com/user-attachments/assets/74b7e16d-9c82-454b-8fb8-9d1af1675082" />


### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested

### Documentation status

- [ ] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low
