### PR TITLE
Fix group framing reset bug

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 - Ensure that correct blend time is always used when backing out of a blend-in-progress.
 - CinemachineVolumeSettings: changes to Focal Length and Aperture settings were not being applied while auto-focus was enabled.
 - InheritPosition was not inheriting the camera position in all cases.
+- GroupFraming extension did not respect PreviousStateIsValid flag, so could not be reset dynamically.
 
 ### Added
 - Added `CinemachineConfiner2D.CameraWasDisplaced()` and `CinemachineConfiner2D.GetCameraDisplacementDistance()` methods.

--- a/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
+++ b/com.unity.cinemachine/Runtime/Behaviours/CinemachineGroupFraming.cs
@@ -139,12 +139,12 @@ namespace Unity.Cinemachine
             public float PreviousOrthoSize;
 #endif
 
-            public void Reset()
+            public void Reset(ref CameraState state)
             {
                 PosAdjustment = Vector3.zero;
                 RotAdjustment = Vector2.zero;
                 FovAdjustment = 0;
-                Stage = CinemachineCore.Stage.Finalize;
+                PreviousOrthoSize = state.Lens.OrthographicSize;
             }
         };
 
@@ -165,10 +165,8 @@ namespace Unity.Cinemachine
             CinemachineCore.Stage stage, ref CameraState state, float deltaTime)
         {
             var extra = GetExtraState<VcamExtraState>(vcam);
-            if (!vcam.PreviousStateIsValid)
-                extra.Reset();
 
-            if (extra.Stage == CinemachineCore.Stage.Finalize || !Application.isPlaying)
+            if (!vcam.PreviousStateIsValid || !Application.isPlaying)
             {
 #if CINEMACHINE_PHYSICS_2D
                 // We have a special compatibility mode for Confiner2D, because it is a common use-case
@@ -198,6 +196,8 @@ namespace Unity.Cinemachine
             if (group == null || !group.IsValid)
                 return;
 
+            if (!vcam.PreviousStateIsValid)
+                extra.Reset(ref state);
             if (state.Lens.Orthographic)
                 OrthoFraming(vcam, group, extra, ref state, deltaTime);
             else


### PR DESCRIPTION
### Purpose of this PR

CINE-988: When the framing component has damping enabled, the camera does not snap to the framed orientation when PreviousStateIsValid is false.

### Testing status

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested

### Documentation status

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

low

