### PR TITLE
Fix for UUM-131977

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.1.7-pre.2] - 2026-03-26
+
+### Bugfixes
+- Fixed blend cancellation not taking into account updates to "cancelled" camera state
+
 ## [3.1.7-pre.1] - 2026-02-24
 
 ### Bugfixes

--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -7,12 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [3.1.7-pre.2] - 2026-03-26
 
 ### Bugfixes
-- Fixed blend cancellation not taking into account updates to "cancelled" camera state
-
-## [3.1.7-pre.1] - 2026-02-24
-
-### Bugfixes
 - Fixed stack frame snapshot not resetting when CameraBlendStack completed blend.
+- Fixed blend cancellation not taking into account updates to "cancelled" camera state
 
 ### Changed
 - Added support for fast enter play mode.

--- a/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
+++ b/com.unity.cinemachine/Runtime/Core/CameraBlendStack.cs
@@ -300,7 +300,6 @@ namespace Unity.Cinemachine
                     // to cancel out the progress made in the opposite direction
                     if (backingOutOfBlend)
                     {
-                        snapshot = true; // always use a snapshot for this to prevent pops
                         duration = duration * normalizedBlendPosition; // skip first part of blend
                         normalizedBlendPosition = 1 - normalizedBlendPosition;
                     }
@@ -312,7 +311,11 @@ namespace Unity.Cinemachine
                     {
                         var blendCopy = new CinemachineBlend();
                         blendCopy.CopyFrom(frame.Blend);
-                        camA = new NestedBlendSource(blendCopy);
+
+                        if (backingOutOfBlend)
+                            camA = new FrozenBlendSource(blendCopy);
+                        else
+                            camA = new NestedBlendSource(blendCopy);
                     }
                 }
                 // For the event, we use the raw outgoing camera, not the actual blend source
@@ -334,7 +337,7 @@ namespace Unity.Cinemachine
             }
 
             // Advance the working blend
-            if (AdvanceBlend(frame.Blend, deltaTime))
+            if (AdvanceBlend(frame, deltaTime))
             {
                 frame.Source.ClearBlend();
                 frame.ClearSnapshot();
@@ -342,22 +345,26 @@ namespace Unity.Cinemachine
             frame.UpdateCameraState(up, deltaTime);
 
             // local function
-            static bool AdvanceBlend(CinemachineBlend blend, float deltaTime)
+            static bool AdvanceBlend(NestedBlendSource source, float deltaTime)
             {
-                bool blendCompleted = false;
-                if (blend.CamA != null)
-                {
+                var blend = source.Blend;
+                if (blend.CamA == null)
+                    return false;
+
+                if (source is not FrozenBlendSource)
                     blend.TimeInBlend += (deltaTime >= 0) ? deltaTime : blend.Duration;
-                    if (blend.IsComplete)
-                    {
-                        // No more blend
-                        blend.ClearBlend();
-                        blendCompleted = true;
-                    }
-                    else if (blend.CamA is NestedBlendSource bs)
-                        AdvanceBlend(bs.Blend, deltaTime);
+
+                if (blend.IsComplete)
+                {
+                    // No more blend
+                    blend.ClearBlend();
+                    return true;
                 }
-                return blendCompleted;
+
+                if (blend.CamA is NestedBlendSource bs)
+                    AdvanceBlend(bs, deltaTime);
+
+                return false;
             }
         }
 
@@ -479,6 +486,16 @@ namespace Unity.Cinemachine
                 m_State.BlendHint &= ~CameraState.BlendHints.FreezeWhenBlendingOut;
                 m_Name ??= source == null ? "(null)" : "*" + source.Name;
             }
+        }
+
+        /// <summary>
+        /// Source for a blend where the time is frozen. Used for cancelling blends where we want
+        /// the source of the cancelling blend to be at the point in time when the blend was cancelled,
+        /// but still update the undelying sources in case they move.
+        /// </summary>
+        class FrozenBlendSource : NestedBlendSource
+        {
+            public FrozenBlendSource(CinemachineBlend blend) : base(blend) {}
         }
     }
 }

--- a/com.unity.cinemachine/Tests/Editor/BlendManagerTests.cs
+++ b/com.unity.cinemachine/Tests/Editor/BlendManagerTests.cs
@@ -279,5 +279,34 @@ namespace Unity.Cinemachine.Tests.Editor
             Assert.That(m_BlendManager.IsBlending, Is.False);
             Assert.AreEqual(1.0f, m_BlendManager.CameraState.RawPosition.x, 0.001f);
         }
+
+        [Test]
+        public void TestBlendCancellationKeepsOutgoingCameraUpdating()
+        {
+            void MoveCameras() {
+                m_Cam1.Position += Vector3.forward;
+                m_Cam2.Position += Vector3.forward;
+            }
+
+            Reset(1); // constant blend time of 1
+            m_Cam1.Position = new Vector3(0, 0, 0);
+            m_Cam2.Position = new Vector3(1, 0, 0);
+
+            // Start with cam1, then blend towards cam2.
+            ProcessFrame(m_Cam1, 0.1f);
+            MoveCameras();
+            ProcessFrame(m_Cam2, 0.5f);
+            MoveCameras();
+            Assume.That(m_BlendManager.IsBlending, Is.True);
+
+            // Cancel/reverse the blend back to cam1 and advance a couple of frames.
+            ProcessFrame(m_Cam1, 0.1f);
+            MoveCameras();
+            ProcessFrame(m_Cam1, 0.1f);
+            Assume.That(m_BlendManager.IsBlending, Is.True);
+
+            // Z coordinate should be the same for both cameras and blend result
+            Assert.AreEqual(m_Cam1.Position.z, m_BlendManager.CameraState.RawPosition.z, 0.001f);
+        }
     }
 }

--- a/com.unity.cinemachine/package.json
+++ b/com.unity.cinemachine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.cinemachine",
   "displayName": "Cinemachine",
-  "version": "3.1.7-pre.1",
+  "version": "3.1.7-pre.2",
   "unity": "2022.3",
   "description": "Smart camera tools for passionate creators. \n\nCinemachine 3 is a newer and better version of Cinemachine, but upgrading an existing project from 2.X will likely require some effort.  If you're considering upgrading an older project, please see our upgrade guide in the user manual.",
   "keywords": [


### PR DESCRIPTION
### Purpose of this PR

[Jira](https://jira.unity3d.com/browse/UUM-131977) [Issue Tracker](https://issuetracker.unity3d.com/product/unity/issues/guid/UUM-131977)

When cancelling a blend, `CameraBlendStack` was using a snapshot of the current state to keep track of the midpoint of the blend. This meant that if one of the two cameras were moving, the midpoint would become outdated.

This commit fixes the issue by introducing FrozenBlendSource an (internal) kind of nested blend source that will not advance the time (AdvanceBlend) but still update the child sources.

### Testing status

- [X] Added an automated test
- [X] Passed all automated tests
- [X] Manually tested

Only manually tested user repro project

### Documentation status

- [X] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

Tech: Low    Halo: Low

### Comments to reviewers

I created a subclass of `NestedBlendSource` instead of modifying it directly because it allows scoping the concept of freezing the time of a blend source to the `CameraBlendStack` type.

I refactored a bit `AdvanceBlend` to make it less indented, only functional change should be `CameraBlendStack.cs:345` (not ticking the time if source if FrozenBlendSource).

### Package version

- [ ] Updated package version
