### PR TITLE
Fix for UUM-143478

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,11 +4,12 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [3.1.7-pre.2] - 2026-03-26
+## [3.1.7-pre.3] - 2026-05-28
 
 ### Bugfixes
 - Fixed stack frame snapshot not resetting when CameraBlendStack completed blend.
 - Fixed blend cancellation not taking into account updates to "cancelled" camera state
+- Added a null check to avoid an issue when deleting a CinemachineCamera with a CinemachinePixelPerfect extension.
 
 ### Changed
 - Added support for fast enter play mode.

--- a/com.unity.cinemachine/Editor/Editors/CinemachinePixelPerfectEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachinePixelPerfectEditor.cs
@@ -23,7 +23,7 @@ namespace Unity.Cinemachine.Editor
 
             ux.TrackAnyUserActivity(() =>
             {
-	        var pp = target as CinemachinePixelPerfect;
+	            var pp = target as CinemachinePixelPerfect;
                 if (pp != null)
                 {
                     bool isValid = pp.HasValidPixelPerfectCamera();

--- a/com.unity.cinemachine/Editor/Editors/CinemachinePixelPerfectEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachinePixelPerfectEditor.cs
@@ -23,7 +23,8 @@ namespace Unity.Cinemachine.Editor
 
             ux.TrackAnyUserActivity(() =>
             {
-                if (target is CinemachinePixelPerfect pp)
+	        var pp = target as CinemachinePixelPerfect;
+                if (pp != null)
                 {
                     bool isValid = pp.HasValidPixelPerfectCamera();
                     infoBox.SetVisible(isValid && pp.enabled);

--- a/com.unity.cinemachine/Editor/Editors/CinemachinePixelPerfectEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachinePixelPerfectEditor.cs
@@ -23,7 +23,7 @@ namespace Unity.Cinemachine.Editor
 
             ux.TrackAnyUserActivity(() =>
             {
-	            var pp = target as CinemachinePixelPerfect;
+                var pp = target as CinemachinePixelPerfect;
                 if (pp != null)
                 {
                     bool isValid = pp.HasValidPixelPerfectCamera();

--- a/com.unity.cinemachine/Editor/Editors/CinemachinePixelPerfectEditor.cs
+++ b/com.unity.cinemachine/Editor/Editors/CinemachinePixelPerfectEditor.cs
@@ -21,12 +21,14 @@ namespace Unity.Cinemachine.Editor
                 "This component requires an active Pixel Perfect Camera component on the Unity Camera.",
                 HelpBoxMessageType.Warning));
 
-            ux.TrackAnyUserActivity(() => 
+            ux.TrackAnyUserActivity(() =>
             {
-                var pp = target as CinemachinePixelPerfect;
-                bool isValid = pp.HasValidPixelPerfectCamera();
-                infoBox.SetVisible(isValid && pp.enabled);
-                helpBox.SetVisible(!isValid);
+                if (target is CinemachinePixelPerfect pp)
+                {
+                    bool isValid = pp.HasValidPixelPerfectCamera();
+                    infoBox.SetVisible(isValid && pp.enabled);
+                    helpBox.SetVisible(!isValid);
+                }
             });
 #else
             ux.Add(new HelpBox("This component is only valid within URP projects", HelpBoxMessageType.Warning));

--- a/com.unity.cinemachine/package.json
+++ b/com.unity.cinemachine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.cinemachine",
   "displayName": "Cinemachine",
-  "version": "3.1.7-pre.2",
+  "version": "3.1.7-pre.3",
   "unity": "2022.3",
   "description": "Smart camera tools for passionate creators. \n\nCinemachine 3 is a newer and better version of Cinemachine, but upgrading an existing project from 2.X will likely require some effort.  If you're considering upgrading an older project, please see our upgrade guide in the user manual.",
   "keywords": [


### PR DESCRIPTION

[Delete any line or section that does not apply]

### Purpose of this PR

Fix for UUM-143478
Added a null check to avoid an issue when deleting a CinemachineCamera with a CinemachinePixelPerfect extension.

### Testing status

[Explanation of what’s tested, how tested and existing or new automation tests. Can include manual testing by self and/or QA. Specify test plans. Rarely acceptable to have no testing.]

- [ ] Added an automated test
- [ ] Passed all automated tests
- [X] Manually tested

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [X] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

[Overall product level assessment of risk of change. Need technical risk & halo effect.]
Risk: Minimal
Halo: Minimal

### Comments to reviewers

[Info per person for what to focus on, or historical info to understand who have previously reviewed and coverage. Help them get context.]

### Package version

[Justification for updating either the patch, minor, or major version according to the [semantic versioning](https://semver.org/spec/v2.0.0.html) rules]

- [X] Updated package version
