### PR TITLE
 Fix for UUM-142866 - Camera jitters when following a moving object

### DIFF
--- a/com.unity.cinemachine/CHANGELOG.md
+++ b/com.unity.cinemachine/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [3.1.8-pre.1] - 2026-09-06
+
+### Bugfixes
+ - Fixed jitter in mix camera sample caused by using physics velocity without smoothing
+
 ## [3.1.7] - 2026-06-08
 
 ### Bugfixes

--- a/com.unity.cinemachine/Samples~/Shared Assets/Scripts/MixCamerasBasedOnSpeed.cs
+++ b/com.unity.cinemachine/Samples~/Shared Assets/Scripts/MixCamerasBasedOnSpeed.cs
@@ -9,6 +9,8 @@ namespace Unity.Cinemachine.Samples
         public float MaxSpeed;
         public Rigidbody Rigidbody;
         CinemachineMixingCamera m_Mixer;
+        float m_CurrentWeight;
+
         void Start()
         {
             m_Mixer = GetComponent<CinemachineMixingCamera>();
@@ -19,7 +21,7 @@ namespace Unity.Cinemachine.Samples
             MaxSpeed = Mathf.Max(1, MaxSpeed);
         }
 
-        void FixedUpdate()
+        void Update()
         {
             if (Rigidbody == null)
                 return;
@@ -29,8 +31,12 @@ namespace Unity.Cinemachine.Samples
 #else
             var t = Mathf.Clamp01(Rigidbody.velocity.magnitude / MaxSpeed);
 #endif
-            m_Mixer.Weight0 = 1 - t;
-            m_Mixer.Weight1 = t;
+            // Weights are not smoothed by cinemachine. If the weights come from a non-smooth source
+            // (in this case physics), it is important to smooth them to avoid jitter
+            m_CurrentWeight = Mathf.Lerp(m_CurrentWeight, t, Time.deltaTime);
+
+            m_Mixer.Weight0 = 1 - m_CurrentWeight;
+            m_Mixer.Weight1 = m_CurrentWeight;
         }
     }
 }

--- a/com.unity.cinemachine/package.json
+++ b/com.unity.cinemachine/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.unity.cinemachine",
   "displayName": "Cinemachine",
-  "version": "3.1.7",
+  "version": "3.1.8-pre.1",
   "unity": "2022.3",
   "description": "Smart camera tools for passionate creators. \n\nCinemachine 3 is a newer and better version of Cinemachine, but upgrading an existing project from 2.X will likely require some effort.  If you're considering upgrading an older project, please see our upgrade guide in the user manual.",
   "keywords": [


### PR DESCRIPTION
The issue was using a value from phisics (linear velocity) as a parameter to a cinemachine mixer, without smoothing the velocity. Since cinemachine does not smooth the weights of a mixer, the jitter in the physics linear velocity is also seen in the camera.

The fix is to:
1) Move the update code to Update from FixedUpdate to make sure updates
   are synced with frames;
2) Damp the linear velocity weight before assigning it to the mixer so
   that the mix is smooth.

[Delete any line or section that does not apply]

### Purpose of this PR

Fix for [UUM-142866](https://jira.unity3d.com/browse/UUM-142866)
This is a backport from 6, see [original pr](https://github.cds.internal.unity3d.com/unity/unity/pull/107634)

### Testing status

Tested manually the 3d sample MixingCamera

- [ ] Added an automated test
- [ ] Passed all automated tests
- [x] Manually tested

### Documentation status

[Overview of how documentation is affected by this change. If there is no effect on documentation, explain why. Otherwise, state which sections are changed and why.]

- [x] Updated [CHANGELOG](https://keepachangelog.com/en/1.0.0/)
- [ ] Updated README (if applicable)
- [ ] Commented all public classes, properties, and methods
- [ ] Updated user documentation

### Technical risk

Tech risk: low - simple code change
Halo effect: minimal - only touches a single sample script

### Comments to reviewers


### Package version

- [x] Updated package version
